### PR TITLE
Add simple mocks for external calls

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -5370,8 +5370,9 @@ ref<Expr> Executor::makeSymbolicValue(Value *value, ExecutionState &state, uint6
   const_cast<Array*>(array)->binding = mo;
   state.addSymbolic(mo, array);
   assert(value && "Attempted to make symbolic value from nullptr Value");
-  ObjectState *os = new ObjectState(
-      mo, array, typeSystemManager->getWrappedType(value->getType()));
+  ObjectState *os = bindObjectInState(
+      state, mo, typeSystemManager->getWrappedType(value->getType()), false,
+      array);
   ref<Expr> result = os->read(0, width);
   return result;
 }

--- a/test/Feature/ExternalCallsMocking.c
+++ b/test/Feature/ExternalCallsMocking.c
@@ -1,0 +1,24 @@
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --output-dir=%t.klee-out --external-calls=all --mock-external-calls %t.bc 2>&1 | FileCheck %s
+// CHECK-NOT: failed external call
+// CHECK: KLEE: done: generated tests = 1
+
+struct Pair {
+  int x, y;
+};
+
+struct Pair divide(int x, int y);
+
+int get_sign(int x);
+
+void increase(int* x);
+
+int main() {
+  int x, y;
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&y, sizeof(y), "y");
+  struct Pair ans = divide(x, y);
+  increase(&ans.x);
+  return get_sign(ans.y);
+}


### PR DESCRIPTION
<!--
Thank you for contributing to KLEE. We are looking forward to reviewing your PR. However, given the small number of active reviewers and our limited time, it might take a while to do so. We aim to get back to each PR within one month, and often do so within one week.

To review your PR, please add a summary of the proposed changes and ensure all items are fulfilled in the checklist above, by placing an "x" inside each applicable pair of brackets. More details about each item can be found in the [Developer's Guide](https://klee.github.io/docs/developers-guide/#pull-requests).
-->

## Summary: 
Add boolean flag --mock-external-calls. If enabled, simple mocking strategy is used for external calls, i.e. return value is made symbolic and then added to the generated test suites.

## Checklist:
- [ ] The PR addresses a single issue.  If it can be divided into multiple independent PRs, please do so.
- [ ] The PR is divided into a logical sequence of commits OR a single commit is sufficient.
- [ ] There are no unnecessary commits (e.g. commits fixing issues in a previous commit in the same PR).
- [ ] Each commit has a meaningful message documenting what it does.
- [ ] All messages added to the codebase, all comments, as well as commit messages are spellchecked.
- [ ] The code is commented OR not applicable/necessary.
- [ ] The patch is formatted via clang-format OR not applicable (if explicitly overridden leave unchecked and explain).
- [ ] There are test cases for the code you added or modified OR no such test cases are required.
