### PR TITLE
Fixes for arm arch

### DIFF
--- a/include/klee/Support/ModuleUtil.h
+++ b/include/klee/Support/ModuleUtil.h
@@ -41,7 +41,7 @@ linkModules(std::vector<std::unique_ptr<llvm::Module>> &modules,
 
 #if defined(__x86_64__) || defined(__i386__)
 #define addFunctionReplacement(from, to)                                       \
-  {#from "f", #to "f"}, {#from, #to}, { #from "l", #to "l" }
+  {#from "f", #to "f"}, {#from, #to}, { "" #from "l", #to "l" }
 
 #define addIntrinsicReplacement(from, to)                                      \
   {"llvm." #from ".f32", #to "f"}, {"llvm." #from ".f64", #to}, {              \
@@ -49,10 +49,11 @@ linkModules(std::vector<std::unique_ptr<llvm::Module>> &modules,
   }
 
 #else
-#define addFunctionReplacement(from, to) {#from "f", #to "f"}, {#from, #to},
+#define addFunctionReplacement(from, to)                                       \
+  {#from "f", #to "f"}, { "" #from, "" #to }
 
 #define addIntrinsicReplacement(from, to)                                      \
-  {"llvm." #from ".f32", #to "f"}, {"llvm." #from ".f64", #to},
+  {"llvm." #from ".f32", #to "f"}, { "llvm." #from ".f64", #to }
 
 #endif
 

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -588,7 +588,7 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
           assert(Z3_get_ast_kind(builder->ctx, arrayElementOffsetExpr) ==
                      Z3_NUMERAL_AST &&
                  "Evaluated size expression has wrong sort");
-          size_t concretizedOffsetValue = 0;
+          uint64_t concretizedOffsetValue = 0;
           assert(Z3_get_numeral_uint64(builder->ctx, arrayElementOffsetExpr,
                                        &concretizedOffsetValue) &&
                  "Failed to get size");


### PR DESCRIPTION
- Delete extra comma from define for floating point 
- Change type of concretizedOffsetValue to uint64_t

After change limited KLEE could be build for arm

Working build example:

```bash
#!/bin/bash
# This script is used to build KLEE as UTBot backend

set -e
set -o pipefail
mkdir -p build
cd build

cmake -G Ninja \
  -DENABLE_SOLVER_Z3=TRUE \
  -DLLVM_CONFIG_BINARY=/usr/bin/llvm-config-13 \
  -DLLVMCC=/usr/bin/clang-13 \
  -DLLVMCXX=/usr/bin/clang++-13 \
  -DENABLE_UNIT_TESTS=TRUE \
  -DENABLE_SYSTEM_TESTS=TRUE \
  -DGTEST_SRC_DIR=/home/utbot/googletest-release-1.11.0 \
  -DGTEST_INCLUDE_DIR=/home/utbot/googletest-release-1.11.0/googletest/include \
  ..
```