### PR TITLE
[fix] Added difference_type for ImmutableTree::iterator

### DIFF
--- a/include/klee/ADT/ImmutableTree.h
+++ b/include/klee/ADT/ImmutableTree.h
@@ -132,6 +132,13 @@ template <class K, class V, class KOV, class CMP>
 class ImmutableTree<K, V, KOV, CMP>::iterator {
   friend class ImmutableTree<K, V, KOV, CMP>;
 
+public:
+  typedef std::bidirectional_iterator_tag iterator_category;
+  typedef V value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef V *pointer;
+  typedef V &reference;
+
 private:
   Node *root; // so can back up from end
   FixedStack<Node *> stack;


### PR DESCRIPTION
For configuration 

```txt
clang version 10.0.0-4ubuntu1
Target: x86_64-pc-linux-gnu
Thread model: posix
```

build fails with error ``error: no type named `difference_type' in `struct std::iterator_traits<klee::ImmutableTree<klee::ref<klee::Target>, klee::ref<klee::Target>, klee::_Identity<klee::ref<klee::Target>>, std::less<klee::ref<klee::Target>>>::iterator>'``on this [line](https://github.com/UnitTestBot/klee/blob/9406351fa133920e003202873b7718ec47271dee/lib/Core/TargetManager.cpp#L86):

```cpp
DistanceResult stateDistance = distance(state, target);
```

Problem resolves with addition of `using` declarations in iterator declaration.