### PR TITLE
Consider function coverage for blocks with calls

### DIFF
--- a/include/klee/ADT/Ref.h
+++ b/include/klee/ADT/Ref.h
@@ -227,6 +227,18 @@ inline std::stringstream &operator<<(std::stringstream &os, const ref<T> &e) {
   return os;
 }
 
+template <class T> class box {
+  friend class ref<box<T>>;
+
+private:
+  /// @brief Required by klee::ref-managed objects
+  class ReferenceCounter _refCount;
+
+public:
+  box(T value_) : value(value_) {}
+  ReferenceCounter count() { return _refCount; }
+  T value;
+};
 } // end namespace klee
 
 namespace llvm {

--- a/include/klee/Core/TerminationTypes.h
+++ b/include/klee/Core/TerminationTypes.h
@@ -40,7 +40,8 @@ enum class StateTerminationClass : std::uint8_t {
   TTYPE(OutOfMemory, 12U, "early")                                             \
   TTYPE(OutOfStackMemory, 13U, "early")                                        \
   TTYPE(MaxCycles, 14U, "early")                                               \
-  TTMARK(EARLY, 14U)                                                           \
+  TTYPE(CoverOnTheFly, 15U, "early")                                           \
+  TTMARK(EARLY, 15U)                                                           \
   TTYPE(Solver, 20U, "solver.err")                                             \
   TTMARK(SOLVERERR, 20U)                                                       \
   TTYPE(Abort, 30U, "abort.err")                                               \

--- a/include/klee/Module/CodeGraphDistance.h
+++ b/include/klee/Module/CodeGraphDistance.h
@@ -30,6 +30,9 @@ class CodeGraphDistance {
       std::unordered_map<KFunction *,
                          std::vector<std::pair<KFunction *, unsigned>>>;
 
+  using functionBranchesSet =
+      std::unordered_map<KFunction *, std::map<KBlock *, std::set<unsigned>>>;
+
 private:
   blockDistanceMap blockDistance;
   blockDistanceMap blockBackwardDistance;
@@ -41,12 +44,16 @@ private:
   functionDistanceList functionSortedDistance;
   functionDistanceList functionSortedBackwardDistance;
 
+  functionBranchesSet functionBranches;
+
 private:
   void calculateDistance(KBlock *bb);
   void calculateBackwardDistance(KBlock *bb);
 
   void calculateDistance(KFunction *kf);
   void calculateBackwardDistance(KFunction *kf);
+
+  void calculateFunctionBranches(KFunction *kf);
 
 public:
   const std::unordered_map<KBlock *, unsigned int> &getDistance(KBlock *kb);
@@ -68,6 +75,8 @@ public:
 
   void getNearestPredicateSatisfying(KBlock *from, KBlockPredicate predicate,
                                      std::set<KBlock *> &result);
+
+  const std::map<KBlock *, std::set<unsigned>> &getFunctionBranches(KFunction *kf);
 };
 
 } // namespace klee

--- a/include/klee/Module/CodeGraphInfo.h
+++ b/include/klee/Module/CodeGraphInfo.h
@@ -1,4 +1,4 @@
-//===-- CodeGraphDistance.h -------------------------------------*- C++ -*-===//
+//===-- CodeGraphInfo.h -----------------------------------------*- C++ -*-===//
 //
 //                     The KLEE Symbolic Virtual Machine
 //
@@ -16,7 +16,7 @@
 
 namespace klee {
 
-class CodeGraphDistance {
+class CodeGraphInfo {
 
   using blockDistanceMap =
       std::unordered_map<KBlock *, std::unordered_map<KBlock *, unsigned>>;
@@ -76,7 +76,8 @@ public:
   void getNearestPredicateSatisfying(KBlock *from, KBlockPredicate predicate,
                                      std::set<KBlock *> &result);
 
-  const std::map<KBlock *, std::set<unsigned>> &getFunctionBranches(KFunction *kf);
+  const std::map<KBlock *, std::set<unsigned>> &
+  getFunctionBranches(KFunction *kf);
 };
 
 } // namespace klee

--- a/include/klee/Module/KModule.h
+++ b/include/klee/Module/KModule.h
@@ -189,6 +189,13 @@ public:
   }
 };
 
+struct KBlockCompare {
+  bool operator()(const KBlock *a, const KBlock *b) const {
+    return a->parent->id < b->parent->id ||
+           (a->parent->id == b->parent->id && a->id < b->id);
+  }
+};
+
 class KConstant {
 public:
   /// Actual LLVM constant this represents.

--- a/lib/Core/DistanceCalculator.cpp
+++ b/lib/Core/DistanceCalculator.cpp
@@ -9,7 +9,7 @@
 
 #include "DistanceCalculator.h"
 #include "ExecutionState.h"
-#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/CodeGraphInfo.h"
 #include "klee/Module/KInstruction.h"
 #include "klee/Module/Target.h"
 
@@ -67,7 +67,7 @@ DistanceResult DistanceCalculator::getDistance(KBlock *kb, TargetKind kind,
 DistanceResult DistanceCalculator::computeDistance(KBlock *kb, TargetKind kind,
                                                    KBlock *target) const {
   const auto &distanceToTargetFunction =
-      codeGraphDistance.getBackwardDistance(target->parent);
+      codeGraphInfo.getBackwardDistance(target->parent);
   weight_type weight = 0;
   WeightResult res = Miss;
   bool isInsideFunction = true;
@@ -99,7 +99,7 @@ DistanceResult DistanceCalculator::getDistance(
 
   KBlock *kb = pc->parent;
   const auto &distanceToTargetFunction =
-      codeGraphDistance.getBackwardDistance(target->parent);
+      codeGraphInfo.getBackwardDistance(target->parent);
   unsigned int minCallWeight = UINT_MAX, minSfNum = UINT_MAX, sfNum = 0;
   auto sfi = frames.rbegin(), sfe = frames.rend();
   bool strictlyAfterKB =
@@ -145,7 +145,7 @@ bool DistanceCalculator::distanceInCallGraph(
     KBlock *target, bool strictlyAfterKB) const {
   distance = UINT_MAX;
   const std::unordered_map<KBlock *, unsigned> &dist =
-      codeGraphDistance.getDistance(origKB);
+      codeGraphInfo.getDistance(origKB);
   KBlock *targetBB = target;
   KFunction *targetF = targetBB->parent;
 
@@ -176,7 +176,7 @@ bool DistanceCalculator::distanceInCallGraph(
     KBlock *target) const {
   distance = UINT_MAX;
   const std::unordered_map<KBlock *, unsigned> &dist =
-      codeGraphDistance.getDistance(kb);
+      codeGraphInfo.getDistance(kb);
 
   for (auto &kCallBlock : kf->kCallBlocks) {
     if (dist.count(kCallBlock) == 0)
@@ -199,7 +199,7 @@ DistanceCalculator::tryGetLocalWeight(KBlock *kb, weight_type &weight,
   KFunction *currentKF = kb->parent;
   KBlock *currentKB = kb;
   const std::unordered_map<KBlock *, unsigned> &dist =
-      codeGraphDistance.getDistance(currentKB);
+      codeGraphInfo.getDistance(currentKB);
   weight = UINT_MAX;
   for (auto &end : localTargets) {
     if (dist.count(end) > 0) {

--- a/lib/Core/DistanceCalculator.h
+++ b/lib/Core/DistanceCalculator.h
@@ -17,7 +17,7 @@ class BasicBlock;
 } // namespace llvm
 
 namespace klee {
-class CodeGraphDistance;
+class CodeGraphInfo;
 class Target;
 
 enum WeightResult : std::uint8_t {
@@ -45,8 +45,8 @@ struct DistanceResult {
 
 class DistanceCalculator {
 public:
-  explicit DistanceCalculator(CodeGraphDistance &codeGraphDistance_)
-      : codeGraphDistance(codeGraphDistance_) {}
+  explicit DistanceCalculator(CodeGraphInfo &codeGraphInfo_)
+      : codeGraphInfo(codeGraphInfo_) {}
 
   DistanceResult getDistance(const ExecutionState &es, KBlock *target);
 
@@ -97,7 +97,7 @@ private:
 
   using StatesSet = std::unordered_set<ExecutionState *>;
 
-  CodeGraphDistance &codeGraphDistance;
+  CodeGraphInfo &codeGraphInfo;
   TargetToSpeculativeStateToDistanceResultMap distanceResultCache;
   StatesSet localStates;
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -128,8 +128,9 @@ ExecutionState::ExecutionState()
     : initPC(nullptr), pc(nullptr), prevPC(nullptr), incomingBBIndex(-1),
       depth(0), ptreeNode(nullptr), steppedInstructions(0),
       steppedMemoryInstructions(0), instsSinceCovNew(0),
-      roundingMode(llvm::APFloat::rmNearestTiesToEven), coveredNew(false),
-      forkDisabled(false), prevHistory_(TargetsHistory::create()),
+      roundingMode(llvm::APFloat::rmNearestTiesToEven),
+      coveredNew(new box<bool>(false)), forkDisabled(false),
+      prevHistory_(TargetsHistory::create()),
       history_(TargetsHistory::create()) {
   setID();
 }
@@ -138,8 +139,9 @@ ExecutionState::ExecutionState(KFunction *kf)
     : initPC(kf->instructions), pc(initPC), prevPC(pc), incomingBBIndex(-1),
       depth(0), ptreeNode(nullptr), steppedInstructions(0),
       steppedMemoryInstructions(0), instsSinceCovNew(0),
-      roundingMode(llvm::APFloat::rmNearestTiesToEven), coveredNew(false),
-      forkDisabled(false), prevHistory_(TargetsHistory::create()),
+      roundingMode(llvm::APFloat::rmNearestTiesToEven),
+      coveredNew(new box<bool>(false)), forkDisabled(false),
+      prevHistory_(TargetsHistory::create()),
       history_(TargetsHistory::create()) {
   pushFrame(nullptr, kf);
   setID();
@@ -149,8 +151,9 @@ ExecutionState::ExecutionState(KFunction *kf, KBlock *kb)
     : initPC(kb->instructions), pc(initPC), prevPC(pc), incomingBBIndex(-1),
       depth(0), ptreeNode(nullptr), steppedInstructions(0),
       steppedMemoryInstructions(0), instsSinceCovNew(0),
-      roundingMode(llvm::APFloat::rmNearestTiesToEven), coveredNew(false),
-      forkDisabled(false), prevHistory_(TargetsHistory::create()),
+      roundingMode(llvm::APFloat::rmNearestTiesToEven),
+      coveredNew(new box<bool>(false)), forkDisabled(false),
+      prevHistory_(TargetsHistory::create()),
       history_(TargetsHistory::create()) {
   pushFrame(nullptr, kf);
   setID();
@@ -189,7 +192,6 @@ ExecutionState *ExecutionState::branch() {
 
   auto *falseState = new ExecutionState(*this);
   falseState->setID();
-  falseState->coveredNew = false;
   falseState->coveredLines.clear();
 
   return falseState;

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -471,7 +471,7 @@ void ExecutionState::increaseLevel() {
   if (prevPC->inst->isTerminator() && kmodule->inMainModule(*kf->function)) {
     auto srcLevel = stack.infoStack().back().multilevel[srcbb].second;
     stack.infoStack().back().multilevel.replace({srcbb, srcLevel + 1});
-    level.insert(srcbb);
+    level.insert(prevPC->parent);
   }
   if (srcbb != dstbb) {
     transitionLevel.insert(std::make_pair(srcbb, dstbb));
@@ -483,7 +483,7 @@ bool ExecutionState::isGEPExpr(ref<Expr> expr) const {
 }
 
 bool ExecutionState::visited(KBlock *block) const {
-  return level.count(block->basicBlock) != 0;
+  return level.count(block) != 0;
 }
 
 bool ExecutionState::reachedTarget(ref<ReachBlockTarget> target) const {

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -290,7 +290,7 @@ public:
   std::uint32_t depth = 0;
 
   /// @brief Exploration level, i.e., number of times KLEE cycled for this state
-  std::unordered_set<llvm::BasicBlock *> level;
+  std::set<KBlock *, KBlockCompare> level;
   std::unordered_set<Transition, TransitionHash> transitionLevel;
 
   /// @brief Address space used by this state (e.g. Global and Heap)

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -369,7 +369,7 @@ public:
   std::uint32_t id = 0;
 
   /// @brief Whether a new instruction was covered in this state
-  bool coveredNew = false;
+  mutable ref<box<bool>> coveredNew;
 
   /// @brief Disables forking for this state. Set by user code
   bool forkDisabled = false;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -50,7 +50,7 @@
 #include "klee/Expr/IndependentSet.h"
 #include "klee/Expr/Symcrete.h"
 #include "klee/Module/Cell.h"
-#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/CodeGraphInfo.h"
 #include "klee/Module/InstructionInfoTable.h"
 #include "klee/Module/KCallable.h"
 #include "klee/Module/KInstruction.h"
@@ -455,13 +455,13 @@ Executor::Executor(LLVMContext &ctx, const InterpreterOptions &opts,
       externalDispatcher(new ExternalDispatcher(ctx)), statsTracker(0),
       pathWriter(0), symPathWriter(0),
       specialFunctionHandler(0), timers{time::Span(TimerInterval)},
-      guidanceKind(opts.Guidance), codeGraphDistance(new CodeGraphDistance()),
-      distanceCalculator(new DistanceCalculator(*codeGraphDistance)),
-      targetCalculator(new TargetCalculator(*codeGraphDistance)),
+      guidanceKind(opts.Guidance), codeGraphInfo(new CodeGraphInfo()),
+      distanceCalculator(new DistanceCalculator(*codeGraphInfo)),
+      targetCalculator(new TargetCalculator(*codeGraphInfo)),
       targetManager(new TargetManager(guidanceKind, *distanceCalculator,
                                       *targetCalculator)),
       targetedExecutionManager(
-          new TargetedExecutionManager(*codeGraphDistance, *targetManager)),
+          new TargetedExecutionManager(*codeGraphInfo, *targetManager)),
       replayKTest(0), replayPath(0), usingSeeds(0), atMemoryLimit(false),
       inhibitForking(false), haltExecution(HaltExecution::NotHalt),
       ivcEnabled(false), debugLogBuffer(debugBufferString) {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -239,6 +239,18 @@ cl::opt<bool> EmitAllErrors(
              "(default=false, i.e. one per (error,instruction) pair)"),
     cl::cat(TestGenCat));
 
+cl::opt<bool> CoverOnTheFly(
+    "cover-on-the-fly", cl::init(false),
+    cl::desc("Generate tests cases for each new covered block or branch "
+             "(default=false, i.e. one per (error,instruction) pair)"),
+    cl::cat(TestGenCat));
+
+cl::opt<unsigned> DelayCoverOnTheFly(
+    "delay-cover-on-the-fly", cl::init(10000),
+    cl::desc("Start on the fly tests generation after this many instructions "
+             "(default=10000)"),
+    cl::cat(TestGenCat));
+
 /* Constraint solving options */
 
 cl::opt<unsigned> MaxSymArraySize(
@@ -4325,8 +4337,36 @@ void Executor::initializeTypeManager() {
   typeSystemManager->initModule();
 }
 
+static bool shouldWriteTest(const ExecutionState &state) {
+  bool coveredNew = state.coveredNew->value;
+  state.coveredNew->value = false;
+  return !OnlyOutputStatesCoveringNew || coveredNew;
+}
+
+static std::string terminationTypeFileExtension(StateTerminationType type) {
+  std::string ret;
+#undef TTYPE
+#undef TTMARK
+#define TTYPE(N, I, S)                                                         \
+  case StateTerminationType::N:                                                \
+    ret = (S);                                                                 \
+    break;
+#define TTMARK(N, I)
+  switch (type) { TERMINATION_TYPES }
+  return ret;
+};
+
 void Executor::executeStep(ExecutionState &state) {
   KInstruction *prevKI = state.prevPC;
+
+  if (CoverOnTheFly && guidanceKind != GuidanceKind::ErrorGuidance &&
+      stats::instructions > DelayCoverOnTheFly && shouldWriteTest(state)) {
+    interpreterHandler->processTestCase(
+        state, nullptr,
+        terminationTypeFileExtension(StateTerminationType::CoverOnTheFly)
+            .c_str());
+  }
+
   if (targetManager->isTargeted(state) && state.targets().empty()) {
     terminateStateEarlyAlgorithm(state, "State missed all it's targets.",
                                  StateTerminationType::MissedAllTargets);
@@ -4510,25 +4550,6 @@ void Executor::terminateState(ExecutionState &state,
 
   removedStates.push_back(&state);
 }
-
-static bool shouldWriteTest(const ExecutionState &state) {
-  bool coveredNew = state.coveredNew->value;
-  state.coveredNew->value = false;
-  return !OnlyOutputStatesCoveringNew || coveredNew;
-}
-
-static std::string terminationTypeFileExtension(StateTerminationType type) {
-  std::string ret;
-#undef TTYPE
-#undef TTMARK
-#define TTYPE(N, I, S)                                                         \
-  case StateTerminationType::N:                                                \
-    ret = (S);                                                                 \
-    break;
-#define TTMARK(N, I)
-  switch (type) { TERMINATION_TYPES }
-  return ret;
-};
 
 void Executor::terminateStateOnExit(ExecutionState &state) {
   auto terminationType = StateTerminationType::Exit;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4053,7 +4053,7 @@ bool Executor::checkMemoryUsage() {
     unsigned idx = theRNG.getInt32() % N;
     // Make two pulls to try and not hit a state that
     // covered new code.
-    if (arr[idx]->coveredNew)
+    if (arr[idx]->coveredNew->value)
       idx = theRNG.getInt32() % N;
 
     std::swap(arr[idx], arr[N - 1]);
@@ -4512,7 +4512,9 @@ void Executor::terminateState(ExecutionState &state,
 }
 
 static bool shouldWriteTest(const ExecutionState &state) {
-  return !OnlyOutputStatesCoveringNew || state.coveredNew;
+  bool coveredNew = state.coveredNew->value;
+  state.coveredNew->value = false;
+  return !OnlyOutputStatesCoveringNew || coveredNew;
 }
 
 static std::string terminationTypeFileExtension(StateTerminationType type) {
@@ -7273,7 +7275,7 @@ void Executor::dumpStates() {
       *os << "{";
       *os << "'depth' : " << es->depth << ", ";
       *os << "'queryCost' : " << es->queryMetaData.queryCost << ", ";
-      *os << "'coveredNew' : " << es->coveredNew << ", ";
+      *os << "'coveredNew' : " << es->coveredNew->value << ", ";
       *os << "'instsSinceCovNew' : " << es->instsSinceCovNew << ", ";
       *os << "'md2u' : " << md2u << ", ";
       *os << "'icnt' : " << icnt << ", ";

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -72,7 +72,7 @@ namespace klee {
 class AddressManager;
 class Array;
 struct Cell;
-class CodeGraphDistance;
+class CodeGraphInfo;
 class DistanceCalculator;
 class ExecutionState;
 class ExternalDispatcher;
@@ -146,7 +146,7 @@ private:
   TimerGroup timers;
   std::unique_ptr<PForest> processForest;
   GuidanceKind guidanceKind;
-  std::unique_ptr<CodeGraphDistance> codeGraphDistance;
+  std::unique_ptr<CodeGraphInfo> codeGraphInfo;
   std::unique_ptr<DistanceCalculator> distanceCalculator;
   std::unique_ptr<TargetCalculator> targetCalculator;
   std::unique_ptr<TargetManager> targetManager;

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -411,7 +411,6 @@ void StatsTracker::stepInstruction(ExecutionState &es) {
         // FIXME: This trick no longer works, we should fix this in the line
         // number propogation.
         es.coveredLines[&ii.file].insert(ii.line);
-        es.coveredNew = true;
         es.instsSinceCovNew = 1;
         ++stats::coveredInstructions;
         stats::uncoveredInstructions += (uint64_t)-1;
@@ -480,7 +479,6 @@ void StatsTracker::markBranchVisited(ExecutionState *visitedTrue,
     uint64_t hasFalse =
         theStatisticManager->getIndexedValue(stats::falseBranches, id);
     if (visitedTrue && !hasTrue) {
-      visitedTrue->coveredNew = true;
       visitedTrue->instsSinceCovNew = 1;
       ++stats::trueBranches;
       if (hasFalse) {
@@ -491,7 +489,6 @@ void StatsTracker::markBranchVisited(ExecutionState *visitedTrue,
       hasTrue = 1;
     }
     if (visitedFalse && !hasFalse) {
-      visitedFalse->coveredNew = true;
       visitedFalse->instsSinceCovNew = 1;
       ++stats::falseBranches;
       if (hasTrue) {

--- a/lib/Core/TargetCalculator.cpp
+++ b/lib/Core/TargetCalculator.cpp
@@ -49,11 +49,22 @@ void TargetCalculator::update(const ExecutionState &state) {
 
     if (!coveredFunctionsInBranches.count(state.prevPC->parent->parent)) {
       unsigned index = 0;
-      coveredBranches[state.prevPC->parent->parent][state.prevPC->parent];
+      if (!coveredBranches[state.prevPC->parent->parent].count(
+              state.prevPC->parent)) {
+        state.coveredNew->value = false;
+        state.coveredNew = new box<bool>(true);
+        coveredBranches[state.prevPC->parent->parent][state.prevPC->parent];
+      }
       for (auto succ : successors(state.getPrevPCBlock())) {
         if (succ == state.getPCBlock()) {
-          coveredBranches[state.prevPC->parent->parent][state.prevPC->parent]
-              .insert(index);
+          if (!coveredBranches[state.prevPC->parent->parent]
+                              [state.prevPC->parent]
+                                  .count(index)) {
+            state.coveredNew->value = false;
+            state.coveredNew = new box<bool>(true);
+            coveredBranches[state.prevPC->parent->parent][state.prevPC->parent]
+                .insert(index);
+          }
           break;
         }
         ++index;

--- a/lib/Core/TargetCalculator.h
+++ b/lib/Core/TargetCalculator.h
@@ -32,7 +32,7 @@ DISABLE_WARNING_POP
 #include <vector>
 
 namespace klee {
-class CodeGraphDistance;
+class CodeGraphInfo;
 class ExecutionState;
 struct TransitionHash;
 
@@ -65,15 +65,15 @@ class TargetCalculator {
   typedef std::unordered_map<llvm::Function *, VisitedBlocks> CoveredBlocks;
 
 public:
-  TargetCalculator(CodeGraphDistance &codeGraphDistance)
-      : codeGraphDistance(codeGraphDistance) {}
+  TargetCalculator(CodeGraphInfo &codeGraphInfo)
+      : codeGraphInfo(codeGraphInfo) {}
 
   void update(const ExecutionState &state);
 
   TargetHashSet calculate(ExecutionState &state);
 
 private:
-  CodeGraphDistance &codeGraphDistance;
+  CodeGraphInfo &codeGraphInfo;
   BlocksHistory blocksHistory;
   TransitionsHistory transitionsHistory;
   CoveredBranches coveredBranches;

--- a/lib/Core/TargetCalculator.h
+++ b/lib/Core/TargetCalculator.h
@@ -42,7 +42,7 @@ typedef std::pair<llvm::BasicBlock *, llvm::BasicBlock *> Transition;
 typedef std::pair<llvm::BasicBlock *, unsigned> Branch;
 
 class TargetCalculator {
-  typedef std::unordered_set<llvm::BasicBlock *> VisitedBlocks;
+  typedef std::unordered_set<KBlock *> VisitedBlocks;
   typedef std::unordered_set<Transition, TransitionHash> VisitedTransitions;
   typedef std::unordered_set<Branch, BranchHash> VisitedBranches;
 
@@ -56,10 +56,11 @@ class TargetCalculator {
       std::unordered_map<llvm::BasicBlock *, VisitedTransitions>>
       TransitionsHistory;
 
-  typedef std::unordered_map<
-      llvm::Function *,
-      std::unordered_map<llvm::BasicBlock *, std::set<unsigned>>>
+  typedef std::unordered_map<KFunction *,
+                             std::map<KBlock *, std::set<unsigned>>>
       CoveredBranches;
+
+  typedef std::unordered_set<KFunction *> CoveredFunctionsBranches;
 
   typedef std::unordered_map<llvm::Function *, VisitedBlocks> CoveredBlocks;
 
@@ -76,6 +77,8 @@ private:
   BlocksHistory blocksHistory;
   TransitionsHistory transitionsHistory;
   CoveredBranches coveredBranches;
+  CoveredFunctionsBranches coveredFunctionsInBranches;
+  CoveredFunctionsBranches fullyCoveredFunctions;
   CoveredBlocks coveredBlocks;
 
   bool differenceIsEmpty(

--- a/lib/Core/TargetManager.cpp
+++ b/lib/Core/TargetManager.cpp
@@ -41,7 +41,11 @@ void TargetManager::updateDone(ExecutionState &state, ref<Target> target) {
   setHistory(state, stateTargetForest.getHistory());
   if (guidance == Interpreter::GuidanceKind::CoverageGuidance ||
       target->shouldFailOnThisTarget()) {
-    reachedTargets.insert(target);
+    if (target->shouldFailOnThisTarget() ||
+        !isa<KCallBlock>(target->getBlock())) {
+      reachedTargets.insert(target);
+    }
+
     for (auto es : states) {
       if (isTargeted(*es)) {
         auto &esTargetForest = targetForest(*es);
@@ -112,7 +116,7 @@ void TargetManager::updateReached(ExecutionState &state) {
 
     if (state.getPrevPCBlock()->getTerminator()->getNumSuccessors() == 0) {
       target = ReachBlockTarget::create(state.prevPC->parent, true);
-    } else {
+    } else if (!isa<KCallBlock>(state.prevPC->parent)) {
       unsigned index = 0;
       for (auto succ : successors(state.getPrevPCBlock())) {
         if (succ == state.getPCBlock()) {

--- a/lib/Core/TargetedExecutionManager.cpp
+++ b/lib/Core/TargetedExecutionManager.cpp
@@ -14,7 +14,7 @@
 
 #include "ExecutionState.h"
 #include "klee/Core/TerminationTypes.h"
-#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/CodeGraphInfo.h"
 #include "klee/Module/KInstruction.h"
 #include "klee/Support/ErrorHandling.h"
 
@@ -375,18 +375,18 @@ bool TargetedExecutionManager::canReach(const ref<Location> &from,
           return true;
         }
 
-        const auto &blockDist = codeGraphDistance.getDistance(fromBlock);
+        const auto &blockDist = codeGraphInfo.getDistance(fromBlock);
         if (blockDist.count(toBlock) != 0) {
           return true;
         }
       } else {
-        const auto &funcDist = codeGraphDistance.getDistance(fromKf);
+        const auto &funcDist = codeGraphInfo.getDistance(fromKf);
         if (funcDist.count(toKf) != 0) {
           return true;
         }
 
         const auto &backwardFuncDist =
-            codeGraphDistance.getBackwardDistance(fromKf);
+            codeGraphInfo.getBackwardDistance(fromKf);
         if (backwardFuncDist.count(toKf) != 0) {
           return true;
         }
@@ -449,7 +449,7 @@ KFunction *TargetedExecutionManager::tryResolveEntryFunction(
           if (i == j) {
             continue;
           }
-          const auto &funcDist = codeGraphDistance.getDistance(resKf);
+          const auto &funcDist = codeGraphInfo.getDistance(resKf);
 
           std::vector<KFunction *> currKFs;
           for (auto block : locToBlocks[result.locations[j]]) {
@@ -462,7 +462,7 @@ KFunction *TargetedExecutionManager::tryResolveEntryFunction(
           for (size_t m = 0; m < currKFs.size() && !curKf; ++m) {
             curKf = currKFs.at(m);
             if (funcDist.count(curKf) == 0) {
-              const auto &curFuncDist = codeGraphDistance.getDistance(curKf);
+              const auto &curFuncDist = codeGraphInfo.getDistance(curKf);
               if (curFuncDist.count(resKf) == 0) {
                 curKf = nullptr;
               } else {

--- a/lib/Core/TargetedExecutionManager.h
+++ b/lib/Core/TargetedExecutionManager.h
@@ -60,7 +60,7 @@ extern llvm::cl::opt<std::string> TimerInterval;
 
 extern llvm::cl::opt<unsigned long long> MaxCycles;
 
-class CodeGraphDistance;
+class CodeGraphInfo;
 
 class TargetedHaltsOnTraces {
   using HaltTypeToConfidence =
@@ -116,7 +116,7 @@ private:
   KFunction *tryResolveEntryFunction(const Result &result,
                                      LocationToBlocks &locToBlocks) const;
 
-  CodeGraphDistance &codeGraphDistance;
+  CodeGraphInfo &codeGraphInfo;
   TargetManager &targetManager;
   StatesSet localStates;
 
@@ -127,9 +127,9 @@ public:
     }
   };
 
-  explicit TargetedExecutionManager(CodeGraphDistance &codeGraphDistance_,
+  explicit TargetedExecutionManager(CodeGraphInfo &codeGraphInfo_,
                                     TargetManager &targetManager_)
-      : codeGraphDistance(codeGraphDistance_), targetManager(targetManager_) {}
+      : codeGraphInfo(codeGraphInfo_), targetManager(targetManager_) {}
   ~TargetedExecutionManager() = default;
   std::map<KFunction *, ref<TargetForest>, KFunctionLess>
   prepareTargets(KModule *kmodule, SarifReport paths);

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -9,7 +9,7 @@
 set(KLEE_MODULE_COMPONENT_SRCS
   CallSplitter.cpp
   Checks.cpp
-  CodeGraphDistance.cpp
+  CodeGraphInfo.cpp
   FunctionAlias.cpp
   InstructionInfoTable.cpp
   InstructionOperandTypeCheckPass.cpp

--- a/lib/Module/CodeGraphDistance.cpp
+++ b/lib/Module/CodeGraphDistance.cpp
@@ -120,6 +120,18 @@ void CodeGraphDistance::calculateBackwardDistance(KFunction *kf) {
   }
 }
 
+void CodeGraphDistance::calculateFunctionBranches(KFunction *kf) {
+  std::map<KBlock *, std::set<unsigned>> &fbranches = functionBranches[kf];
+  for (auto &kb : kf->blocks) {
+    fbranches[kb.get()];
+    for (unsigned branch = 0;
+         branch < kb->basicBlock->getTerminator()->getNumSuccessors();
+         ++branch) {
+      fbranches[kb.get()].insert(branch);
+    }
+  }
+}
+
 const std::unordered_map<KBlock *, unsigned> &
 CodeGraphDistance::getDistance(KBlock *kb) {
   if (blockDistance.count(kb) == 0)
@@ -199,4 +211,11 @@ void CodeGraphDistance::getNearestPredicateSatisfying(
     }
     nodes.pop_front();
   }
+}
+
+const std::map<KBlock *, std::set<unsigned>> &
+CodeGraphDistance::getFunctionBranches(KFunction *kf) {
+  if (functionBranches.count(kf) == 0)
+    calculateFunctionBranches(kf);
+  return functionBranches.at(kf);
 }

--- a/lib/Module/CodeGraphInfo.cpp
+++ b/lib/Module/CodeGraphInfo.cpp
@@ -1,5 +1,4 @@
-//===-- CodeGraphDistance.cpp
-//---------------------------------------------------===//
+//===-- CodeGraphInfo.cpp -------------------------------------------------===//
 //
 //                     The KLEE Symbolic Virtual Machine
 //
@@ -8,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/CodeGraphInfo.h"
 
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
@@ -21,7 +20,7 @@ DISABLE_WARNING_POP
 
 using namespace klee;
 
-void CodeGraphDistance::calculateDistance(KBlock *bb) {
+void CodeGraphInfo::calculateDistance(KBlock *bb) {
   auto blockMap = bb->parent->blockMap;
   std::unordered_map<KBlock *, unsigned int> &dist = blockDistance[bb];
   std::vector<std::pair<KBlock *, unsigned>> &sort = blockSortedDistance[bb];
@@ -42,7 +41,7 @@ void CodeGraphDistance::calculateDistance(KBlock *bb) {
   }
 }
 
-void CodeGraphDistance::calculateBackwardDistance(KBlock *bb) {
+void CodeGraphInfo::calculateBackwardDistance(KBlock *bb) {
   auto blockMap = bb->parent->blockMap;
   std::unordered_map<KBlock *, unsigned int> &bdist = blockBackwardDistance[bb];
   std::vector<std::pair<KBlock *, unsigned>> &bsort =
@@ -64,7 +63,7 @@ void CodeGraphDistance::calculateBackwardDistance(KBlock *bb) {
   }
 }
 
-void CodeGraphDistance::calculateDistance(KFunction *kf) {
+void CodeGraphInfo::calculateDistance(KFunction *kf) {
   auto &functionMap = kf->parent->functionMap;
   std::unordered_map<KFunction *, unsigned int> &dist = functionDistance[kf];
   std::vector<std::pair<KFunction *, unsigned>> &sort =
@@ -92,7 +91,7 @@ void CodeGraphDistance::calculateDistance(KFunction *kf) {
   }
 }
 
-void CodeGraphDistance::calculateBackwardDistance(KFunction *kf) {
+void CodeGraphInfo::calculateBackwardDistance(KFunction *kf) {
   auto &functionMap = kf->parent->functionMap;
   auto &callMap = kf->parent->callMap;
   std::unordered_map<KFunction *, unsigned int> &bdist =
@@ -120,7 +119,7 @@ void CodeGraphDistance::calculateBackwardDistance(KFunction *kf) {
   }
 }
 
-void CodeGraphDistance::calculateFunctionBranches(KFunction *kf) {
+void CodeGraphInfo::calculateFunctionBranches(KFunction *kf) {
   std::map<KBlock *, std::set<unsigned>> &fbranches = functionBranches[kf];
   for (auto &kb : kf->blocks) {
     fbranches[kb.get()];
@@ -133,63 +132,64 @@ void CodeGraphDistance::calculateFunctionBranches(KFunction *kf) {
 }
 
 const std::unordered_map<KBlock *, unsigned> &
-CodeGraphDistance::getDistance(KBlock *kb) {
+CodeGraphInfo::getDistance(KBlock *kb) {
   if (blockDistance.count(kb) == 0)
     calculateDistance(kb);
   return blockDistance.at(kb);
 }
 
 const std::unordered_map<KBlock *, unsigned> &
-CodeGraphDistance::getBackwardDistance(KBlock *kb) {
+CodeGraphInfo::getBackwardDistance(KBlock *kb) {
   if (blockBackwardDistance.count(kb) == 0)
     calculateBackwardDistance(kb);
   return blockBackwardDistance.at(kb);
 }
 
 const std::vector<std::pair<KBlock *, unsigned int>> &
-CodeGraphDistance::getSortedDistance(KBlock *kb) {
+CodeGraphInfo::getSortedDistance(KBlock *kb) {
   if (blockDistance.count(kb) == 0)
     calculateDistance(kb);
   return blockSortedDistance.at(kb);
 }
 
 const std::vector<std::pair<KBlock *, unsigned int>> &
-CodeGraphDistance::getSortedBackwardDistance(KBlock *kb) {
+CodeGraphInfo::getSortedBackwardDistance(KBlock *kb) {
   if (blockBackwardDistance.count(kb) == 0)
     calculateBackwardDistance(kb);
   return blockSortedBackwardDistance.at(kb);
 }
 
 const std::unordered_map<KFunction *, unsigned> &
-CodeGraphDistance::getDistance(KFunction *kf) {
+CodeGraphInfo::getDistance(KFunction *kf) {
   if (functionDistance.count(kf) == 0)
     calculateDistance(kf);
   return functionDistance.at(kf);
 }
 
 const std::unordered_map<KFunction *, unsigned> &
-CodeGraphDistance::getBackwardDistance(KFunction *kf) {
+CodeGraphInfo::getBackwardDistance(KFunction *kf) {
   if (functionBackwardDistance.count(kf) == 0)
     calculateBackwardDistance(kf);
   return functionBackwardDistance.at(kf);
 }
 
 const std::vector<std::pair<KFunction *, unsigned int>> &
-CodeGraphDistance::getSortedDistance(KFunction *kf) {
+CodeGraphInfo::getSortedDistance(KFunction *kf) {
   if (functionDistance.count(kf) == 0)
     calculateDistance(kf);
   return functionSortedDistance.at(kf);
 }
 
 const std::vector<std::pair<KFunction *, unsigned int>> &
-CodeGraphDistance::getSortedBackwardDistance(KFunction *kf) {
+CodeGraphInfo::getSortedBackwardDistance(KFunction *kf) {
   if (functionBackwardDistance.count(kf) == 0)
     calculateBackwardDistance(kf);
   return functionSortedBackwardDistance.at(kf);
 }
 
-void CodeGraphDistance::getNearestPredicateSatisfying(
-    KBlock *from, KBlockPredicate predicate, std::set<KBlock *> &result) {
+void CodeGraphInfo::getNearestPredicateSatisfying(KBlock *from,
+                                                  KBlockPredicate predicate,
+                                                  std::set<KBlock *> &result) {
   std::set<KBlock *> visited;
 
   auto blockMap = from->parent->blockMap;
@@ -214,7 +214,7 @@ void CodeGraphDistance::getNearestPredicateSatisfying(
 }
 
 const std::map<KBlock *, std::set<unsigned>> &
-CodeGraphDistance::getFunctionBranches(KFunction *kf) {
+CodeGraphInfo::getFunctionBranches(KFunction *kf) {
   if (functionBranches.count(kf) == 0)
     calculateFunctionBranches(kf);
   return functionBranches.at(kf);

--- a/lib/Module/Target.cpp
+++ b/lib/Module/Target.cpp
@@ -10,7 +10,7 @@
 #include "klee/Module/Target.h"
 #include "klee/Module/TargetHash.h"
 
-#include "klee/Module/CodeGraphDistance.h"
+#include "klee/Module/CodeGraphInfo.h"
 #include "klee/Module/KInstruction.h"
 
 #include <set>

--- a/test/Feature/CoverOnTheFly.c
+++ b/test/Feature/CoverOnTheFly.c
@@ -1,0 +1,35 @@
+// ASAN fails because KLEE does not cleanup states with -dump-states-on-halt=false
+// REQUIRES: not-asan
+// RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --only-output-states-covering-new --max-instructions=2000 --delay-cover-on-the-fly=500 --dump-states-on-halt=false --cover-on-the-fly --search=bfs --use-guided-search=none --output-dir=%t.klee-out %t.bc 2>&1 | FileCheck %s
+
+#include "klee/klee.h"
+
+#define a (2)
+int main() {
+  int res = 0;
+  for (;;) {
+    int n = klee_int("n");
+    switch (n) {
+    case 1:
+      res += 1;
+      break;
+    case 2:
+      res += 2;
+      break;
+    case 3:
+      res += 3;
+      break;
+    case 4:
+      res += 4;
+      break;
+
+    default:
+      break;
+    }
+  }
+}
+
+// CHECK: KLEE: done: completed paths = 0
+// CHECK: KLEE: done: generated tests = 5

--- a/test/Feature/CoverageCheck.c
+++ b/test/Feature/CoverageCheck.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -emit-llvm %O0opt -c -o %t.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --use-cov-check=instruction-based --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %klee --use-guided-search=none --use-cov-check=instruction-based --output-dir=%t.klee-out %t.bc > %t.log
 #include "klee/klee.h"
 
 #define a (2)


### PR DESCRIPTION
Fix `only-output-states-covering-new` and add `cover-on-the-fly` options.