### PR TITLE
SARIF reports

### DIFF
--- a/include/klee/ADT/ImmutableList.h
+++ b/include/klee/ADT/ImmutableList.h
@@ -97,9 +97,9 @@ public:
     node->values.push_back(value);
   }
 
-  bool empty() { return size() == 0; }
+  bool empty() const { return size() == 0; }
 
-  const T &back() {
+  const T &back() const {
     assert(node && "requiers not empty list");
     auto it = iterator(node.get());
     it.get = size() - 1;
@@ -109,6 +109,10 @@ public:
   ImmutableList() : node(){};
   ImmutableList(const ImmutableList<T> &il)
       : node(std::make_shared<ImmutableListNode>(il)) {}
+  ImmutableList &operator=(const ImmutableList<T> &il) {
+    node = std::make_shared<ImmutableListNode>(il);
+    return *this;
+  }
 };
 
 } // namespace klee

--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -38,6 +38,7 @@ class raw_fd_ostream;
 namespace klee {
 class ExecutionState;
 struct SarifReport;
+struct ToolJson;
 class Interpreter;
 class TreeStreamWriter;
 
@@ -57,6 +58,8 @@ public:
 
   virtual void processTestCase(const ExecutionState &state, const char *message,
                                const char *suffix, bool isError = false) = 0;
+
+  virtual ToolJson info() const = 0;
 };
 
 /// [File][Line][Column] -> Opcode
@@ -227,6 +230,10 @@ public:
                                 LogType logFormat = STP) = 0;
 
   virtual bool getSymbolicSolution(const ExecutionState &state, KTest &res) = 0;
+
+  virtual void addSARIFReport(const ExecutionState &state) = 0;
+
+  virtual SarifReportJson getSARIFReport() const = 0;
 
   virtual void logState(const ExecutionState &state, int id,
                         std::unique_ptr<llvm::raw_fd_ostream> &f) = 0;

--- a/include/klee/Expr/SourceBuilder.h
+++ b/include/klee/Expr/SourceBuilder.h
@@ -5,8 +5,8 @@
 
 namespace klee {
 
-class KInstruction;
-class KGlobalVariable;
+struct KInstruction;
+struct KGlobalVariable;
 
 template <typename T, typename Eq> class SparseStorage;
 template <typename T> class ref;

--- a/include/klee/Module/KModule.h
+++ b/include/klee/Module/KModule.h
@@ -381,6 +381,8 @@ public:
 
   KBlock *getKBlock(const llvm::BasicBlock *bb);
 
+  bool inMainModule(const llvm::Instruction &i);
+
   bool inMainModule(const llvm::Function &f);
 
   bool inMainModule(const llvm::GlobalVariable &v);

--- a/include/klee/Module/LocationInfo.h
+++ b/include/klee/Module/LocationInfo.h
@@ -1,16 +1,18 @@
-////===-- LocationInfo.h ----------------------------------*- C++ -*-===//
-////
-////                     The KLEE Symbolic Virtual Machine
-////
-//// This file is distributed under the University of Illinois Open Source
-//// License. See LICENSE.TXT for details.
-////
-////===----------------------------------------------------------------------===//
+////===-- LocationInfo.h ----------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef KLEE_LOCATIONINFO_H
 #define KLEE_LOCATIONINFO_H
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace llvm {
@@ -21,11 +23,27 @@ class Module;
 } // namespace llvm
 
 namespace klee {
+struct PhysicalLocationJson;
+}
 
+namespace klee {
+
+/// @brief Immutable struct representing location in source code.
 struct LocationInfo {
-  std::string file;
-  size_t line;
-  size_t column;
+  /// @brief Path to source file for that location.
+  const std::string file;
+
+  /// @brief Code line in source file.
+  const uint64_t line;
+
+  /// @brief Column number in source file.
+  const std::optional<uint64_t> column;
+
+  /// @brief Converts location info to SARIFs representation
+  /// of location.
+  /// @param location location info in source code.
+  /// @return SARIFs representation of location.
+  PhysicalLocationJson serialize() const;
 };
 
 LocationInfo getLocationInfo(const llvm::Function *func);

--- a/include/klee/Module/SarifReport.h
+++ b/include/klee/Module/SarifReport.h
@@ -58,6 +58,11 @@ std::string getErrorsString(const std::vector<ReachWithError> &errors);
 
 struct FunctionInfo;
 struct KBlock;
+struct LocationInfo;
+
+struct Message {
+  std::string text;
+};
 
 struct ArtifactLocationJson {
   std::optional<std::string> uri;
@@ -76,6 +81,7 @@ struct PhysicalLocationJson {
 };
 
 struct LocationJson {
+  std::optional<Message> message;
   std::optional<PhysicalLocationJson> physicalLocation;
 };
 
@@ -92,10 +98,6 @@ struct CodeFlowJson {
   std::vector<ThreadFlowJson> threadFlows;
 };
 
-struct Message {
-  std::string text;
-};
-
 struct Fingerprints {
   std::string cooddy_uid;
 };
@@ -110,6 +112,7 @@ static void from_json(const json &j, Fingerprints &p) {
 
 struct ResultJson {
   std::optional<std::string> ruleId;
+  std::optional<std::string> level;
   std::optional<Message> message;
   std::optional<unsigned> id;
   std::optional<Fingerprints> fingerprints;
@@ -117,8 +120,17 @@ struct ResultJson {
   std::vector<CodeFlowJson> codeFlows;
 };
 
+struct RuleJson {
+  std::string id;
+  std::optional<std::string> name;
+  std::optional<Message> shortDescription;
+  std::optional<std::string> helpUri;
+};
+
 struct DriverJson {
   std::string name;
+  std::optional<std::string> informationUri;
+  std::vector<RuleJson> rules;
 };
 
 struct ToolJson {
@@ -131,8 +143,12 @@ struct RunJson {
 };
 
 struct SarifReportJson {
+  std::string version;
   std::vector<RunJson> runs;
 };
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RuleJson, id, name,
+                                                shortDescription, helpUri)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ArtifactLocationJson, uri)
 
@@ -142,7 +158,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RegionJson, startLine, endLine,
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PhysicalLocationJson,
                                                 artifactLocation, region)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LocationJson, physicalLocation)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LocationJson, message,
+                                                physicalLocation)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ThreadFlowLocationJson,
                                                 location, metadata)
@@ -153,17 +170,18 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(CodeFlowJson, threadFlows)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Message, text)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ResultJson, ruleId, message, id,
-                                                fingerprints, codeFlows,
-                                                locations)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ResultJson, ruleId, level,
+                                                message, id, fingerprints,
+                                                codeFlows, locations)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DriverJson, name)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DriverJson, name,
+                                                informationUri, rules)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ToolJson, driver)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(RunJson, results, tool)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SarifReportJson, runs)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SarifReportJson, version, runs)
 
 struct Location {
   struct LocationHash {

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -10,10 +10,12 @@ add_library(kleeCore
   AddressManager.cpp
   AddressSpace.cpp
   CallPathManager.cpp
+  CodeLocation.cpp
   Context.cpp
   CoreStats.cpp
   CXXTypeSystem/CXXTypeManager.cpp
   DistanceCalculator.cpp
+  EventRecorder.cpp
   ExecutionState.cpp
   Executor.cpp
   ExecutorUtil.cpp

--- a/lib/Core/CodeEvent.h
+++ b/lib/Core/CodeEvent.h
@@ -1,0 +1,203 @@
+//===-- CodeEvent.h ---------------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef KLEE_CODE_EVENT_H
+#define KLEE_CODE_EVENT_H
+
+#include "CodeLocation.h"
+#include "klee/ADT/Ref.h"
+
+#include "klee/Module/KModule.h"
+#include "klee/Module/KValue.h"
+#include "klee/Module/SarifReport.h"
+
+#include "klee/Support/CompilerWarning.h"
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/IR/Instructions.h"
+#include "llvm/Support/Casting.h"
+DISABLE_WARNING_POP
+
+#include <optional>
+#include <string>
+
+namespace klee {
+
+/// @brief Base unit for storing information about event from source code.
+/// Chain of such units may form a history for particular execution state.
+class CodeEvent {
+public:
+  /// @brief Server for LLVM RTTI purposes.
+  const enum EventKind { ALLOC, BR, CALL, ERR, RET } kind;
+
+public:
+  /// @brief Required by klee::ref-managed objects
+  class ReferenceCounter _refCount;
+
+  /// @brief Location information for the event
+  const ref<CodeLocation> location;
+
+  explicit CodeEvent(EventKind kind, const ref<CodeLocation> &location)
+      : kind(kind), location(location) {}
+
+  /// @brief Additional info to current event.
+  /// @return String describing event.
+  virtual std::string description() const = 0;
+
+  /// @brief Serialize event to the JSON format.
+  /// @return JSON object describing event.
+  LocationJson serialize() const {
+    LocationJson result;
+
+    result.message = {{description()}};
+    result.physicalLocation = {{location->serialize()}};
+
+    return result;
+  }
+
+  /// @brief Kind of event used for LLVM RTTI.
+  /// @return Kind of event.
+  EventKind getKind() const { return kind; }
+
+  virtual ~CodeEvent() = default;
+};
+
+/// @brief Event describing any allocating event.
+struct AllocEvent : public CodeEvent {
+  AllocEvent(ref<CodeLocation> location)
+      : CodeEvent(EventKind::ALLOC, location) {}
+
+  std::string description() const override {
+    const KValue *source = location->source;
+    if (llvm::isa<KGlobalVariable>(source)) {
+      return std::string("Global memory allocation");
+    }
+
+    if (llvm::isa<llvm::AllocaInst>(source->unwrap())) {
+      return std::string("Local memory allocation");
+    }
+
+    return std::string("Heap memory allocation");
+  }
+
+  static bool classof(const CodeEvent *rhs) {
+    return rhs->getKind() == EventKind::ALLOC;
+  }
+};
+
+/// @brief Event describing conditional `br` event.
+class BrEvent : public CodeEvent {
+private:
+  /// @brief Described chosen branch event: `true` if
+  /// `then`-branch was chosen and `false` otherwise.
+  bool chosenBranch = true;
+
+public:
+  explicit BrEvent(const ref<CodeLocation> &location)
+      : CodeEvent(EventKind::BR, location) {}
+
+  /// @brief Modifies chosen branch for `this` event.
+  /// @param branch true if condition in chosen branch is true and false
+  /// otherwise.
+  /// @return Reference to this object.
+  /// @note This function does not return modified copy of this object; it
+  /// returns *this* object.
+  BrEvent &withBranch(bool branch) {
+    chosenBranch = branch;
+    return *this;
+  }
+
+  std::string description() const override {
+    return std::string("Choosing ") +
+           (chosenBranch ? std::string("true") : std::string("false")) +
+           std::string(" branch");
+  }
+
+  static bool classof(const CodeEvent *rhs) {
+    return rhs->getKind() == EventKind::BR;
+  }
+};
+
+/// @brief Event describing conditional `call` to function event.
+class CallEvent : public CodeEvent {
+private:
+  /// @brief Called function. Provides additional info
+  /// for event description.
+  const KFunction *const called;
+
+public:
+  explicit CallEvent(const ref<CodeLocation> &location,
+                     const KFunction *const called)
+      : CodeEvent(EventKind::CALL, location), called(called) {}
+
+  std::string description() const override {
+    return std::string("Calling '") + called->getName().str() +
+           std::string("()'");
+  }
+
+  static bool classof(const CodeEvent *rhs) {
+    return rhs->getKind() == EventKind::CALL;
+  }
+};
+
+/// @brief Event describing any error event.
+/// Kind of error is described in ruleID.
+struct ErrorEvent : public CodeEvent {
+public:
+  /// @brief ID for this error.
+  const StateTerminationType ruleID;
+
+  /// @brief Message describing this error.
+  const std::string message;
+
+  /// @brief Event associated with this error
+  /// which may be treated as a "source" of error
+  /// (e.g. memory allocation for Out-Of-Bounds error).
+  const std::optional<ref<CodeEvent>> source;
+
+  ErrorEvent(const ref<CodeEvent> &source, const ref<CodeLocation> &sink,
+             StateTerminationType ruleID, const std::string &message)
+      : CodeEvent(EventKind::ERR, sink), ruleID(ruleID), message(message),
+        source(source) {}
+
+  ErrorEvent(const ref<CodeLocation> &sink, StateTerminationType ruleID,
+             const std::string &message)
+      : CodeEvent(EventKind::ERR, sink), ruleID(ruleID), message(message),
+        source(std::nullopt) {}
+
+  std::string description() const override { return message; }
+
+  static bool classof(const CodeEvent *rhs) {
+    return rhs->getKind() == EventKind::ERR;
+  }
+};
+
+/// @brief Event describing conditional `return` from function event.
+class ReturnEvent : public CodeEvent {
+private:
+  /// @brief Function to which control flow returns.
+  const KFunction *const caller;
+
+public:
+  explicit ReturnEvent(const ref<CodeLocation> &location,
+                       const KFunction *const caller)
+      : CodeEvent(EventKind::RET, location), caller(caller) {}
+
+  std::string description() const override {
+    return std::string("Returning to '") + caller->getName().str() +
+           std::string("()'");
+  }
+
+  static bool classof(const CodeEvent *rhs) {
+    return rhs->getKind() == EventKind::RET;
+  }
+};
+
+} // namespace klee
+
+#endif // KLEE_CODE_EVENT_H

--- a/lib/Core/CodeLocation.cpp
+++ b/lib/Core/CodeLocation.cpp
@@ -1,0 +1,47 @@
+//===-- CodeLocation.cpp ----------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "CodeLocation.h"
+
+#include "klee/ADT/Ref.h"
+#include "klee/Module/LocationInfo.h"
+#include "klee/Module/SarifReport.h"
+
+#include <optional>
+#include <string>
+
+using namespace klee;
+
+CodeLocation::CodeLocation(const Path::PathIndex &pathIndex,
+                           const KValue *source,
+                           const std::string &sourceFilename,
+                           uint64_t sourceCodeLine,
+                           std::optional<uint64_t> sourceCodeColumn)
+    : pathIndex(pathIndex), source(source),
+      location(LocationInfo{sourceFilename, sourceCodeLine, sourceCodeColumn}) {
+}
+
+ref<CodeLocation>
+CodeLocation::create(const Path::PathIndex &pathIndex, const KValue *source,
+                     const std::string &sourceFilename, uint64_t sourceCodeLine,
+                     std::optional<uint64_t> sourceCodeColumn = std::nullopt) {
+  return new CodeLocation(pathIndex, source, sourceFilename, sourceCodeLine,
+                          sourceCodeColumn);
+}
+
+ref<CodeLocation>
+CodeLocation::create(const KValue *source, const std::string &sourceFilename,
+                     uint64_t sourceCodeLine,
+                     std::optional<uint64_t> sourceCodeColumn = std::nullopt) {
+  return new CodeLocation(Path::PathIndex{0, 0}, source, sourceFilename,
+                          sourceCodeLine, sourceCodeColumn);
+}
+
+PhysicalLocationJson CodeLocation::serialize() const {
+  return location.serialize();
+}

--- a/lib/Core/CodeLocation.h
+++ b/lib/Core/CodeLocation.h
@@ -1,0 +1,82 @@
+//===-- CodeLocation.h ------------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef KLEE_CODE_LOCATION_H
+#define KLEE_CODE_LOCATION_H
+
+#include "klee/ADT/Ref.h"
+#include "klee/Expr/Path.h"
+#include "klee/Module/LocationInfo.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace klee {
+
+struct PhysicalLocationJson;
+struct KValue;
+
+/// @brief Represents the location in source code with additional
+/// information about place in the state's path.
+struct CodeLocation {
+  /// @brief Required by klee::ref-managed objects
+  class ReferenceCounter _refCount;
+
+  /// @brief Path index in `Path`.
+  const Path::PathIndex pathIndex;
+
+  /// @brief Corresponding llvm entity.
+  const KValue *source;
+
+  /// @brief Location in source code.
+  const LocationInfo location;
+
+private:
+  CodeLocation(const Path::PathIndex &pathIndex, const KValue *source,
+               const std::string &sourceFilename, uint64_t sourceCodeLine,
+               std::optional<uint64_t> sourceCodeColumn);
+
+  CodeLocation(const CodeLocation &) = delete;
+  CodeLocation &operator=(const CodeLocation &) = delete;
+
+public:
+  /// @brief Factory method for `CodeLocation` enhanced with `PathIndex`
+  /// in history. Wraps constructed objects in the ref to provide
+  /// zero-cost copying of code locations.
+  /// @param sourceFilename Name of source file to which location refers.
+  /// @param sourceCodeLine Line in source to which location refers.
+  /// @param sourceCodeColumn Column in source code to which location refers.
+  /// @return `CodeLocation` representing the location in source code.
+  static ref<CodeLocation> create(const Path::PathIndex &pathIndex,
+                                  const KValue *source,
+                                  const std::string &sourceFilename,
+                                  uint64_t sourceCodeLine,
+                                  std::optional<uint64_t> sourceCodeColumn);
+
+  /// @brief Factory method for `CodeLocation`. Wraps constructed
+  /// objects in the ref to provide zero-cost copying of code locations.
+  /// @param sourceFilename Name of source file to which location refers.
+  /// @param sourceCodeLine Line in source to which location refers.
+  /// @param sourceCodeColumn Column in source code to which location refers.
+  /// @return `CodeLocation` representing the location in source code.
+  static ref<CodeLocation> create(const KValue *source,
+                                  const std::string &sourceFilename,
+                                  uint64_t sourceCodeLine,
+                                  std::optional<uint64_t> sourceCodeColumn);
+
+  /// @brief Converts code location info to SARIFs representation
+  /// of location.
+  /// @param location location info in source code.
+  /// @return SARIFs representation of location.
+  PhysicalLocationJson serialize() const;
+};
+
+}; // namespace klee
+
+#endif // KLEE_CODE_LOCATION_H

--- a/lib/Core/EventRecorder.cpp
+++ b/lib/Core/EventRecorder.cpp
@@ -1,0 +1,93 @@
+//===-- EventRecorder.cpp ---------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "EventRecorder.h"
+#include "CodeEvent.h"
+
+#include "klee/ADT/ImmutableList.h"
+#include "klee/ADT/Ref.h"
+#include "klee/Expr/Path.h"
+#include "klee/Module/SarifReport.h"
+
+#include <cassert>
+#include <optional>
+#include <utility>
+
+using namespace klee;
+
+EventRecorder::EventRecorder(const EventRecorder &rhs) : events(rhs.events) {}
+
+EventRecorder &EventRecorder::operator=(const EventRecorder &rhs) {
+  events = rhs.events;
+  return *this;
+}
+
+void EventRecorder::record(const ref<CodeEvent> &event) {
+  assert(event->location);
+  assert((empty() ||
+          Path::PathIndexCompare{}(last()->location->pathIndex,
+                                   event->location->pathIndex) ||
+          !Path::PathIndexCompare{}(event->location->pathIndex,
+                                    last()->location->pathIndex)) &&
+         "Event must have later pathIndex than last recorded");
+  events.push_back(event);
+}
+
+void EventRecorder::append(const EventRecorder &rhs) {
+  for (const auto &event : rhs.events) {
+    record(event);
+  }
+}
+
+CodeFlowJson EventRecorder::serialize() const {
+  CodeFlowJson codeFlow{};
+  ThreadFlowJson threadFlow{};
+
+  for (const auto &event : events) {
+    LocationJson location = event->serialize();
+    ThreadFlowLocationJson threadFlowLocation{{std::move(location)},
+                                              std::nullopt};
+    threadFlow.locations.push_back(std::move(threadFlowLocation));
+  }
+
+  codeFlow.threadFlows.push_back(std::move(threadFlow));
+
+  return codeFlow;
+}
+
+EventRecorder EventRecorder::inRange(const Path::PathIndex &begin,
+                                     const Path::PathIndex &end) const {
+  EventRecorder result;
+
+  if (Path::PathIndexCompare{}(end, begin)) {
+    return result;
+  }
+
+  for (const auto &event : events) {
+    const Path::PathIndex &eventPathIndex = event->location->pathIndex;
+    if (!Path::PathIndexCompare{}(eventPathIndex, begin)) {
+      if (Path::PathIndexCompare{}(end, eventPathIndex)) {
+        break;
+      }
+      result.record(event);
+    }
+  }
+
+  return result;
+}
+
+bool EventRecorder::empty() const { return events.empty(); }
+
+ref<CodeEvent> EventRecorder::last() const { return events.back(); }
+
+EventRecorder EventRecorder::tail(const Path::PathIndex &begin) const {
+  if (events.empty()) {
+    return EventRecorder();
+  }
+  return inRange(begin, events.back()->location->pathIndex);
+}

--- a/lib/Core/EventRecorder.h
+++ b/lib/Core/EventRecorder.h
@@ -1,0 +1,72 @@
+//===-- EventRecorder.h -----------------------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef KLEE_EVENT_RECORDER_H
+#define KLEE_EVENT_RECORDER_H
+
+#include "klee/Expr/Path.h"
+
+namespace klee {
+
+template <typename T> class ref;
+template <typename T> class ImmutableList;
+struct CodeFlowJson;
+class CodeEvent;
+
+/// @brief Class capable of storing code events
+/// and serializing them into SARIF format.
+class EventRecorder {
+private:
+  /// @brief Inner storage of code events.
+  ImmutableList<ref<CodeEvent>> events;
+
+public:
+  EventRecorder() = default;
+
+  EventRecorder(const EventRecorder &);
+  EventRecorder &operator=(const EventRecorder &);
+  ~EventRecorder() = default;
+
+  /// @brief Remembers event.
+  /// @param event Event to record.
+  void record(const ref<CodeEvent> &event);
+
+  /// @brief Appends all events from the given `EventRecorder`
+  /// to this recorder.
+  /// @param rhs `EventRecorder` to get events from.
+  void append(const EventRecorder &rhs);
+
+  /// @brief Returns events from the history in specified range.
+  /// @param begin range begin.
+  /// @param end range end.
+  /// @return `EventRecorder` containing recorder events from inner storage.
+  EventRecorder inRange(const Path::PathIndex &begin,
+                        const Path::PathIndex &end) const;
+
+  /// @brief Returns events from the history from the givent event.
+  /// @param begin range begin.
+  /// @return `EventRecorder` containing recorder events from inner storage.
+  EventRecorder tail(const Path::PathIndex &begin) const;
+
+  /// @brief Returns last recorder event.
+  /// @return Last recorded `CodeEvent`.
+  ref<CodeEvent> last() const;
+
+  /// @brief Tests whether this event recorder is empty.
+  /// @return `true` if there are no events have been recorded.
+  bool empty() const;
+
+  /// @brief Serializes events in this recorder to SARIF format.
+  /// @return Structure ready for wrapping into json
+  /// (i.e. `json(serialize())`) and serialization.
+  CodeFlowJson serialize() const;
+};
+
+} // namespace klee
+
+#endif // KLEE_EVENT_RECORDER_H

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -22,6 +22,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/IR/Function.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
@@ -161,10 +162,10 @@ ExecutionState::ExecutionState(const ExecutionState &state)
       stack(state.stack), stackBalance(state.stackBalance),
       incomingBBIndex(state.incomingBBIndex), depth(state.depth),
       level(state.level), addressSpace(state.addressSpace),
-      constraints(state.constraints), targetForest(state.targetForest),
-      pathOS(state.pathOS), symPathOS(state.symPathOS),
-      coveredLines(state.coveredLines), symbolics(state.symbolics),
-      resolvedPointers(state.resolvedPointers),
+      constraints(state.constraints), eventsRecorder(state.eventsRecorder),
+      targetForest(state.targetForest), pathOS(state.pathOS),
+      symPathOS(state.symPathOS), coveredLines(state.coveredLines),
+      symbolics(state.symbolics), resolvedPointers(state.resolvedPointers),
       cexPreferences(state.cexPreferences), arrayNames(state.arrayNames),
       steppedInstructions(state.steppedInstructions),
       steppedMemoryInstructions(state.steppedMemoryInstructions),

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -31,9 +31,13 @@
 #include "klee/System/Time.h"
 #include "klee/Utilities/Math.h"
 
+#include "CodeLocation.h"
+#include "EventRecorder.h"
+
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/IR/Function.h"
 DISABLE_WARNING_POP
 
@@ -41,6 +45,7 @@ DISABLE_WARNING_POP
 #include <deque>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -66,6 +71,12 @@ extern llvm::cl::opt<unsigned long long> MaxCyclesBeforeStuck;
 struct CallStackFrame {
   KInstIterator caller;
   KFunction *kf;
+
+  /// @brief Location of a return statement in current stack frame.
+  /// @details Serves for a very special case when actual location
+  /// of `return` statement in source code can not be deduced from
+  /// LLVM IR `dbg!` metadata.
+  std::optional<ref<CodeLocation>> returnLocation;
 
   CallStackFrame(KInstIterator caller_, KFunction *kf_)
       : caller(caller_), kf(kf_) {}
@@ -133,6 +144,24 @@ public:
   inline const info_stack_ty &infoStack() const { return infoStack_; }
   inline info_stack_ty &infoStack() { return infoStack_; }
   inline const call_stack_ty &uniqueFrames() const { return uniqueFrames_; }
+
+  void forceReturnLocation(const ref<CodeLocation> &location) {
+    assert(!callStack_.empty() && "Call stack should contain at least one "
+                                  "stack frame to force return location");
+    std::optional<ref<CodeLocation>> &callStackReturnLocation =
+        callStack_.back().returnLocation;
+    assert(!callStackReturnLocation.has_value() &&
+           "Forced return location twice for a single call stack");
+
+    callStackReturnLocation.emplace(location);
+  }
+
+  std::optional<ref<CodeLocation>> forcedReturnLocation() const {
+    if (callStack_.empty()) {
+      return std::nullopt;
+    }
+    return callStack_.back().returnLocation;
+  }
 
   inline unsigned size() const { return callStack_.size(); }
   inline size_t stackRegisterSize() const { return stackSize; }
@@ -300,6 +329,10 @@ public:
 
   /// @brief Constraints collected so far
   PathConstraints constraints;
+
+  /// @brief Storage for the source code events (e.g. changing control flow or
+  /// errors)
+  EventRecorder eventsRecorder;
 
   /// @brief Key points which should be visited through execution
   TargetForest targetForest;

--- a/lib/Core/ExternalDispatcher.h
+++ b/lib/Core/ExternalDispatcher.h
@@ -24,7 +24,7 @@ class LLVMContext;
 
 namespace klee {
 class ExternalDispatcherImpl;
-class KCallable;
+struct KCallable;
 class ExternalDispatcher {
 private:
   ExternalDispatcherImpl *impl;

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -10,6 +10,7 @@
 #ifndef KLEE_MEMORY_H
 #define KLEE_MEMORY_H
 
+#include "CodeLocation.h"
 #include "MemoryManager.h"
 #include "TimingSolver.h"
 #include "klee/ADT/Ref.h"
@@ -90,7 +91,7 @@ public:
   /// "Location" for which this memory object was allocated. This
   /// should be either the allocating instruction or the global object
   /// it was allocated for (or whatever else makes sense).
-  const llvm::Value *allocSite;
+  ref<CodeLocation> allocSite;
 
   // DO NOT IMPLEMENT
   MemoryObject(const MemoryObject &b);
@@ -106,7 +107,7 @@ public:
   MemoryObject(
       uint64_t _address, unsigned _size, uint64_t alignment, bool _isLocal,
       bool _isGlobal, bool _isFixed, bool _isLazyInitialized,
-      const llvm::Value *_allocSite, MemoryManager *_parent,
+      ref<CodeLocation> _allocSite, MemoryManager *_parent,
       ref<Expr> _addressExpr = nullptr, ref<Expr> _sizeExpr = nullptr,
       unsigned _timestamp = 0 /* unused if _isLazyInitialized is false*/)
       : id(counter++), timestamp(_timestamp), address(_address),
@@ -125,7 +126,7 @@ public:
   ~MemoryObject();
 
   /// Get an identifying string for this allocation.
-  void getAllocInfo(std::string &result) const;
+  std::string getAllocInfo() const;
 
   void setName(const std::string &_name) const { this->name = _name; }
 
@@ -188,8 +189,8 @@ public:
     if (size != b.size)
       return (size < b.size ? -1 : 1);
 
-    if (allocSite != b.allocSite)
-      return (allocSite < b.allocSite ? -1 : 1);
+    if (allocSite->source != b.allocSite->source)
+      return (allocSite->source < b.allocSite->source ? -1 : 1);
 
     assert(isLazyInitialized == b.isLazyInitialized);
     return 0;

--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -130,7 +130,7 @@ MemoryManager::~MemoryManager() {
 
 MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
                                       bool isGlobal, bool isLazyInitialiazed,
-                                      const llvm::Value *allocSite,
+                                      ref<CodeLocation> allocSite,
                                       size_t alignment, ref<Expr> addressExpr,
                                       ref<Expr> sizeExpr, unsigned timestamp,
                                       IDType id) {
@@ -195,7 +195,7 @@ MemoryObject *MemoryManager::allocate(uint64_t size, bool isLocal,
 }
 
 MemoryObject *MemoryManager::allocateFixed(uint64_t address, uint64_t size,
-                                           const llvm::Value *allocSite) {
+                                           ref<CodeLocation> allocSite) {
 #ifndef NDEBUG
   for (objects_ty::iterator it = objects.begin(), ie = objects.end(); it != ie;
        ++it) {

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -26,6 +26,7 @@ namespace klee {
 class MemoryObject;
 class ArrayCache;
 class AddressManager;
+struct CodeLocation;
 
 typedef uint64_t IDType;
 
@@ -53,12 +54,12 @@ public:
    * memory.
    */
   MemoryObject *allocate(uint64_t size, bool isLocal, bool isGlobal,
-                         bool isLazyInitialiazed, const llvm::Value *allocSite,
+                         bool isLazyInitialiazed, ref<CodeLocation> allocSite,
                          size_t alignment, ref<Expr> addressExpr = ref<Expr>(),
                          ref<Expr> sizeExpr = ref<Expr>(),
                          unsigned timestamp = 0, IDType id = 0);
   MemoryObject *allocateFixed(uint64_t address, uint64_t size,
-                              const llvm::Value *allocSite);
+                              ref<CodeLocation> allocSite);
   void deallocate(const MemoryObject *mo);
   void markFreed(MemoryObject *mo);
   ArrayCache *getArrayCache() const { return arrayCache; }

--- a/lib/Expr/APFloatEval.cpp
+++ b/lib/Expr/APFloatEval.cpp
@@ -12,6 +12,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/raw_ostream.h"
 DISABLE_WARNING_POP
 

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -21,6 +21,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #if LLVM_VERSION_CODE >= LLVM_VERSION(13, 0)

--- a/lib/Module/CMakeLists.txt
+++ b/lib/Module/CMakeLists.txt
@@ -20,12 +20,14 @@ set(KLEE_MODULE_COMPONENT_SRCS
   KModule.cpp
   KType.cpp
   KValue.cpp
+  LocalVarDeclarationFinderPass.cpp
   LowerSwitch.cpp
   ModuleUtil.cpp
   Optimize.cpp
   OptNone.cpp
   PhiCleaner.cpp
   RaiseAsm.cpp
+  ReturnLocationFinderPass.cpp
   ReturnSplitter.cpp
   SarifReport.cpp
   Target.cpp

--- a/lib/Module/KInstruction.cpp
+++ b/lib/Module/KInstruction.cpp
@@ -81,7 +81,7 @@ size_t KInstruction::getLine() const {
 
 size_t KInstruction::getColumn() const {
   auto locationInfo = getLocationInfo(inst());
-  return locationInfo.column;
+  return locationInfo.column.value_or(0);
 }
 
 std::string KInstruction::getSourceFilepath() const {

--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -304,6 +304,10 @@ void KModule::optimiseAndPrepare(
   // going to be unresolved. We really need to handle the intrinsics
   // directly I think?
   legacy::PassManager pm3;
+
+  pm3.add(new ReturnLocationFinderPass());
+  pm3.add(new LocalVarDeclarationFinderPass());
+
   if (opts.Simplify)
     pm3.add(createCFGSimplificationPass());
   switch (SwitchType) {
@@ -486,6 +490,10 @@ KBlock *KModule::getKBlock(const llvm::BasicBlock *bb) {
 
 bool KModule::inMainModule(const llvm::Function &f) {
   return mainModuleFunctions.count(f.getName().str()) != 0;
+}
+
+bool KModule::inMainModule(const llvm::Instruction &i) {
+  return inMainModule(*i.getParent()->getParent());
 }
 
 bool KModule::inMainModule(const GlobalVariable &v) {

--- a/lib/Module/LocalVarDeclarationFinderPass.cpp
+++ b/lib/Module/LocalVarDeclarationFinderPass.cpp
@@ -1,0 +1,48 @@
+//===-- LocalVarDeclarationFinderPass.cpp -----------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "Passes.h"
+
+#include "klee/Support/CompilerWarning.h"
+
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/Casting.h"
+DISABLE_WARNING_POP
+
+using namespace klee;
+
+////////////////////////////////////////////////
+
+char LocalVarDeclarationFinderPass::ID = 0;
+
+bool LocalVarDeclarationFinderPass::runOnFunction(llvm::Function &function) {
+  bool anyChanged = false;
+
+  for (const llvm::BasicBlock &block : function) {
+    for (const llvm::Instruction &instruction : block) {
+      if (const llvm::DbgDeclareInst *debugDeclareInstruction =
+              llvm::dyn_cast<const llvm::DbgDeclareInst>(&instruction)) {
+        llvm::Value *source = debugDeclareInstruction->getAddress();
+        if (llvm::Instruction *sourceInstruction =
+                llvm::dyn_cast<llvm::Instruction>(source)) {
+          sourceInstruction->setDebugLoc(
+              debugDeclareInstruction->getDebugLoc());
+          anyChanged = true;
+        }
+      }
+    }
+  }
+
+  return anyChanged;
+}

--- a/lib/Module/Passes.h
+++ b/lib/Module/Passes.h
@@ -220,6 +220,46 @@ public:
   ReturnSplitter() : llvm::FunctionPass(ID) {}
   bool runOnFunction(llvm::Function &F) override;
 };
+
+/// @brief Pass able to find the actual location of
+/// `return` statements in source code.
+///
+/// @details For function with multiple `return` statements
+/// clang compiler generates LLVM IR with exactly one `ret`
+/// instruction. `return` statements transform to the:
+///   ```
+///     ret_reg = val
+///     br ret_block
+///   ...
+///   ret_block:
+///     ret_val = load ret_reg
+///     ret ret_val
+///   ```
+/// This pass finds such constructions and marks
+/// `br ret_block` with `md_ret` metadata.
+class ReturnLocationFinderPass : public llvm::FunctionPass {
+public:
+  static char ID;
+  ReturnLocationFinderPass() : llvm::FunctionPass(ID) {}
+  bool runOnFunction(llvm::Function &) override;
+};
+
+/// @brief Pass able to find line in source code with
+/// declaration of local variable.
+///
+/// @details "Construction" of local variable in LLVM IR
+/// is represented as allocation of memory in the beginning
+/// of each function and subsequent call of `llvm.dbg.declare`
+/// function on allocated memory. This pass moves `!dbg` infos
+/// from calls to mentioned functions to the corresponding `alloca`
+/// instructions.
+class LocalVarDeclarationFinderPass : public llvm::FunctionPass {
+public:
+  static char ID;
+  LocalVarDeclarationFinderPass() : llvm::FunctionPass(ID) {}
+  bool runOnFunction(llvm::Function &) override;
+};
+
 } // namespace klee
 
 #endif /* KLEE_PASSES_H */

--- a/lib/Module/ReturnLocationFinderPass.cpp
+++ b/lib/Module/ReturnLocationFinderPass.cpp
@@ -1,0 +1,91 @@
+//===-- ReturnLocationFinderPass.cpp ----------------------------*- C++ -*-===//
+//
+//                     The KLEEF Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "Passes.h"
+
+#include "klee/Support/CompilerWarning.h"
+
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/Casting.h"
+DISABLE_WARNING_POP
+
+#include <cassert>
+
+using namespace klee;
+
+/// @brief Determines whether given block is a "return" block.
+/// @param block block to check.
+/// @return true iff block is a "return" block.
+///
+/// @details Check is based on form of return block: either
+/// just a single `ret` instruction without return value or
+/// exactly two instructions `load` and `ret` where `ret`
+/// return value loaded by `load`.
+static bool isReturnBlock(const llvm::BasicBlock *block) {
+  bool shouldReturnConstant = false;
+
+  switch (block->size()) {
+  case 2: {
+    if (!llvm::isa<const llvm::LoadInst>(&block->front())) {
+      return false;
+    }
+    shouldReturnConstant = true;
+    [[fallthrough]];
+  }
+  case 1: {
+    const llvm::ReturnInst *returnInstruction =
+        llvm::dyn_cast<const llvm::ReturnInst>(&block->back());
+    if (!returnInstruction) {
+      return false;
+    }
+    // `isa_and_nonnull` required as return value may not exist
+    return shouldReturnConstant == llvm::isa_and_nonnull<const llvm::Constant>(
+                                       returnInstruction->getReturnValue());
+  }
+  default: {
+    return false;
+  }
+  }
+}
+
+////////////////////////////////////////////////
+
+char ReturnLocationFinderPass::ID = 0;
+
+bool ReturnLocationFinderPass::runOnFunction(llvm::Function &function) {
+  llvm::BasicBlock &terminatorBlock = function.back();
+
+  if (!isReturnBlock(&terminatorBlock)) {
+    return false;
+  }
+
+  for (auto predecessorBlock : predecessors(&terminatorBlock)) {
+    llvm::Instruction *predecessorTerminator =
+        predecessorBlock->getTerminator();
+    // Predecessor instruction should be a `br` instruction.
+    // Sometimes optimizer may generate `switch` instruction
+    // with branch at return block. But it is not mapped
+    // to a `return` statement in source code.
+    if (llvm::isa<llvm::BranchInst>(predecessorTerminator)) {
+      // Attach metadata to the instruction.
+      llvm::MDTuple *predecessorMetadataTuple =
+          llvm::MDNode::get(predecessorTerminator->getContext(), {});
+      predecessorTerminator->setMetadata("md.ret", predecessorMetadataTuple);
+    }
+  }
+
+  return true;
+}

--- a/lib/Module/SarifReport.cpp
+++ b/lib/Module/SarifReport.cpp
@@ -373,7 +373,7 @@ bool Location::isInside(const llvm::Function *f,
           locInfo.line >= startLine && locInfo.column <= *endColumn &&
           locInfo.column >= *startColumn &&
           origInsts.at(locInfo.line)
-                  .at(locInfo.column)
+                  .at(locInfo.column.value_or(0))
                   .count(inst.getOpcode()) != 0) {
         return true;
       }

--- a/lib/Solver/BitwuzlaBuilder.cpp
+++ b/lib/Solver/BitwuzlaBuilder.cpp
@@ -23,6 +23,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 DISABLE_WARNING_POP

--- a/lib/Solver/BitwuzlaBuilder.h
+++ b/lib/Solver/BitwuzlaBuilder.h
@@ -14,6 +14,12 @@
 #include "klee/Expr/ArrayExprHash.h"
 #include "klee/Expr/ExprHashMap.h"
 
+#include "klee/Support/CompilerWarning.h"
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
+DISABLE_WARNING_POP
+
 #include <bitwuzla/cpp/bitwuzla.h>
 #include <unordered_map>
 

--- a/lib/Solver/BitwuzlaSolver.cpp
+++ b/lib/Solver/BitwuzlaSolver.cpp
@@ -530,7 +530,9 @@ bool BitwuzlaSolverImpl::internalRunSolver(
     timeoutInMicroSeconds = UINT_MAX;
   BitwuzlaTerminator terminator(timeoutInMicroSeconds);
 
-  struct sigaction action, old_action;
+  struct sigaction action {};
+  struct sigaction old_action {};
+
   action.sa_handler = signal_handler;
   action.sa_flags = 0;
   sigaction(SIGINT, &action, &old_action);

--- a/lib/Solver/Z3BitvectorBuilder.cpp
+++ b/lib/Solver/Z3BitvectorBuilder.cpp
@@ -22,6 +22,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 DISABLE_WARNING_POP

--- a/lib/Solver/Z3BitvectorBuilder.h
+++ b/lib/Solver/Z3BitvectorBuilder.h
@@ -19,6 +19,12 @@
 #include <unordered_map>
 #include <z3.h>
 
+#include "klee/Support/CompilerWarning.h"
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
+DISABLE_WARNING_POP
+
 namespace klee {
 class Z3BitvectorBuilder : public Z3Builder {
 private:

--- a/lib/Support/RoundingModeUtil.cpp
+++ b/lib/Support/RoundingModeUtil.cpp
@@ -11,6 +11,7 @@
 #include "klee/Support/CompilerWarning.h"
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/ErrorHandling.h"
 DISABLE_WARNING_POP
 

--- a/test/Feature/SymbolicSizes/FirstAndLastElements.c
+++ b/test/Feature/SymbolicSizes/FirstAndLastElements.c
@@ -1,6 +1,6 @@
 // RUN: %clang %s -g -emit-llvm %O0opt -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --check-out-of-memory --use-sym-size-alloc --use-merged-pointer-dereference=true %t1.bc 2>&1 | FileCheck %s
+// RUN: %klee --output-dir=%t.klee-out --check-out-of-memory --use-sym-size-alloc --use-merged-pointer-dereference=true --max-sym-alloc=128 %t1.bc 2>&1 | FileCheck %s
 
 #include "klee/klee.h"
 #include <assert.h>

--- a/test/SARIF/GSAC/ContextSensitive/ContextSensitive.c
+++ b/test/SARIF/GSAC/ContextSensitive/ContextSensitive.c
@@ -1,0 +1,36 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+#include <stdlib.h>
+
+int *foo(int size) {
+  int *data = (int *)malloc(size * sizeof(int));
+  return data;
+}
+
+int main() {
+  int size = 5;
+  int *first_data = foo(size++);  // Call of 'foo(5)'
+  int *second_data = foo(size--); // Call of 'foo(6)'
+
+  for (int i = 0; i <= size; i++) {
+    // Length of 'first_data' is 5 and 'size' also is 5
+    first_data[i] = i; // buffer-overflow
+  }
+  for (int i = 0; i <= size; i++) {
+    // Length of 'second_data' is 6
+    second_data[i] = i;
+  }
+  free(first_data);
+  free(second_data);
+}

--- a/test/SARIF/GSAC/ContextSensitive/pattern.sarif
+++ b/test/SARIF/GSAC/ContextSensitive/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "ContextSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 22,
+                            "startLine": 17
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "ContextSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 19,
+                            "startLine": 28
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/EASY02/EASY02.c
+++ b/test/SARIF/GSAC/EASY02/EASY02.c
@@ -1,0 +1,23 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#include <stdlib.h>
+
+int main() {
+  int size = 10;
+  int *arr = malloc(size * sizeof(int)); // Memory allocation
+  // Access is out of bounds
+  arr[size] = 4; // buffer-overflow
+  free(arr);
+}

--- a/test/SARIF/GSAC/EASY02/pattern.sarif
+++ b/test/SARIF/GSAC/EASY02/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "EASY02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 14,
+                            "startLine": 19
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "EASY02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 21
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/EASY02_fix/EASY02_fix.c
+++ b/test/SARIF/GSAC/EASY02_fix/EASY02_fix.c
@@ -1,0 +1,22 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#include <stdlib.h>
+
+int main() {
+  int size = 10;
+  int *arr = malloc(size * sizeof(int));
+  arr[size - 1] = 4;
+  free(arr);
+}

--- a/test/SARIF/GSAC/EASY03/EASY03.c
+++ b/test/SARIF/GSAC/EASY03/EASY03.c
@@ -1,0 +1,26 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#include <stdlib.h>
+
+int main() {
+  int *data;
+  int size = 5;
+  data = malloc(size * sizeof(int)); // Memory allocation
+  for (int i = 0; i <= size; i++) {  // Last iteration of this cycle is (size + 1)_th
+    // In the last iteration access is out of bounds
+    data[i] = i; // buffer-overflow
+  }
+  free(data);
+}

--- a/test/SARIF/GSAC/EASY03/pattern.sarif
+++ b/test/SARIF/GSAC/EASY03/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "EASY03.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 10,
+                            "startLine": 20
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "EASY03.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 23
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/EASY03_fix/EASY03_fix.c
+++ b/test/SARIF/GSAC/EASY03_fix/EASY03_fix.c
@@ -1,0 +1,25 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#include <stdlib.h>
+
+int main() {
+  int *data;
+  int size = 5;
+  data = malloc(size * sizeof(int));
+  for (int i = 0; i < size; i++) {
+    data[i] = i;
+  }
+  free(data);
+}

--- a/test/SARIF/GSAC/FieldSensitive/FieldSensitive.c
+++ b/test/SARIF/GSAC/FieldSensitive/FieldSensitive.c
@@ -1,0 +1,41 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#include <stdlib.h>
+
+struct Data {
+  int *first_data;
+  int *second_data;
+};
+
+void foo(struct Data *data, int size) {
+  data->second_data = (int *)malloc(size * sizeof(int)); // Allocated 20 bytes of memory
+  size++;
+  data->first_data = (int *)malloc(size * sizeof(int)); // Allocated 24 bytes of memory
+}
+
+int main() {
+  int size = 5;
+  struct Data data;
+  foo(&data, size);
+  for (int i = 0; i <= size; i++) {
+    data.first_data[i] = i;
+  }
+  // Length of 'second_data' is 5 and 'size' also is 5
+  for (int i = 0; i <= size; i++) {
+    data.second_data[i] = i; // buffer-overflow
+  }
+  free(data.first_data);
+  free(data.second_data);
+}

--- a/test/SARIF/GSAC/FieldSensitive/pattern.sarif
+++ b/test/SARIF/GSAC/FieldSensitive/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "FieldSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 30,
+                            "startLine": 23
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "FieldSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 25,
+                            "startLine": 37
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/FlowSensitive/FlowSensitive.c
+++ b/test/SARIF/GSAC/FlowSensitive/FlowSensitive.c
@@ -1,0 +1,54 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * CVE-2022-23462
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IWNUMBUF_SIZE 70
+#define NEWBUF_SIZE 32
+
+void iwjson_ftoa(long double val, char *buf, size_t *out_len) {
+  // If size of 'buf' is 32 which is less than 64, then will be buffer-overflow
+  int len = snprintf(buf, 64, "%.8Lf", val);
+  if (len <= 0) {
+    buf[0] = '\0';
+    *out_len = 0;
+    return;
+  }
+  while (len > 0 && buf[len - 1] == '0') {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  if ((len > 0) && (buf[len - 1] == '.')) {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  *out_len = (size_t)len;
+}
+
+int main() {
+  char buf[IWNUMBUF_SIZE];
+  char new_buf[NEWBUF_SIZE];
+  char *alias_to_buf = buf;
+  size_t *out_len = malloc(sizeof(size_t));
+  *out_len = 50;
+  iwjson_ftoa(12345678912345678912345.1234, alias_to_buf, out_len);
+  alias_to_buf = new_buf;
+  iwjson_ftoa(12345678912345678912345.1234, alias_to_buf, out_len);
+  free(out_len);
+}

--- a/test/SARIF/GSAC/FlowSensitive/pattern.sarif
+++ b/test/SARIF/GSAC/FlowSensitive/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Local memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "FlowSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 8,
+                            "startLine": 46
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "FlowSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 27
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/HARD01/HARD01.c
+++ b/test/SARIF/GSAC/HARD01/HARD01.c
@@ -1,0 +1,49 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-23462
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IWNUMBUF_SIZE 32
+char buf[IWNUMBUF_SIZE];
+
+void iwjson_ftoa(long double val, size_t *out_len, size_t buf_size) {
+  // Length of 'buf' is 32. But size of 'maxlen' in 'snprintf' is 64
+  int len = snprintf(buf, buf_size, "%.8Lf", val); // buffer overflow
+  if (len <= 0) {
+    buf[0] = '\0';
+    *out_len = 0;
+    return;
+  }
+  while (len > 0 && buf[len - 1] == '0') {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  if ((len > 0) && (buf[len - 1] == '.')) {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  *out_len = (size_t)len;
+}
+
+int main() {
+  size_t *out_len = malloc(sizeof(size_t));
+  *out_len = 50;
+  iwjson_ftoa(12345678912345678912345.1234, out_len, 64);
+  free(out_len);
+}

--- a/test/SARIF/GSAC/HARD01/pattern.sarif
+++ b/test/SARIF/GSAC/HARD01/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Global memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "HARD01.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": null,
+                            "startLine": 23
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "HARD01.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 27
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/HARD01_fix/HARD01_fix.c
+++ b/test/SARIF/GSAC/HARD01_fix/HARD01_fix.c
@@ -1,0 +1,48 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-23462 (fixed)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IWNUMBUF_SIZE 32
+char buf[IWNUMBUF_SIZE];
+
+void iwjson_ftoa(long double val, size_t *out_len, size_t buf_size) {
+  int len = snprintf(buf, buf_size, "%.8Lf", val);
+  if (len <= 0) {
+    buf[0] = '\0';
+    *out_len = 0;
+    return;
+  }
+  while (len > 0 && buf[len - 1] == '0') {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  if ((len > 0) && (buf[len - 1] == '.')) {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  *out_len = (size_t)len;
+}
+
+int main() {
+  size_t *out_len = malloc(sizeof(size_t));
+  *out_len = 50;
+  iwjson_ftoa(12345678912345678912345.1234, out_len, IWNUMBUF_SIZE);
+  free(out_len);
+}

--- a/test/SARIF/GSAC/HARD02/HARD02.c
+++ b/test/SARIF/GSAC/HARD02/HARD02.c
@@ -1,0 +1,47 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-26768
+ */
+#include "HARD02.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char initialLogFileName[FILENAMESIZE] = "";
+
+void EXPORT_CALL lou_logFile(const char *fileName) {
+  if (fileName == NULL || fileName[0] == 0)
+    return;
+  if (initialLogFileName[0] == 0)
+    // Size of 'fileName' is greater than 'FILENAMESIZE'
+    strcpy(initialLogFileName, fileName); // buffer-overflow
+  logFile = fopen(fileName, "a");
+  if (logFile == NULL && initialLogFileName[0] != 0)
+    logFile = fopen(initialLogFileName, "a");
+  if (logFile == NULL) {
+    fprintf(stderr, "Cannot open log file %s\n", fileName);
+    logFile = stderr;
+  }
+}
+
+int main() {
+  const int sz = 260;
+  char *fileName = malloc(sz + 1); // Allocate 261 bytes of memory
+  memset(fileName, 's', sz);
+  fileName[sz] = '\0';
+  lou_logFile(fileName);
+  free(fileName);
+}

--- a/test/SARIF/GSAC/HARD02/HARD02.h
+++ b/test/SARIF/GSAC/HARD02/HARD02.h
@@ -1,0 +1,35 @@
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#ifndef HARD02_H
+#define HARD02_H
+
+#include <stddef.h>
+
+#define EXPORT_CALL
+
+#ifndef __FILE_defined
+#define __FILE_defined 1
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+#endif
+
+extern FILE *stderr;
+#define stderr stderr
+
+#define FILENAMESIZE 256
+
+static FILE *logFile = NULL;
+
+void EXPORT_CALL lou_logFile(const char *fileName);
+
+#endif // HARD02_H

--- a/test/SARIF/GSAC/HARD02/pattern.sarif
+++ b/test/SARIF/GSAC/HARD02/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Global memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "HARD02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": null,
+                            "startLine": 23
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "HARD02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 5,
+                            "startLine": 30
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/HARD02_fix/HARD02_fix.c
+++ b/test/SARIF/GSAC/HARD02_fix/HARD02_fix.c
@@ -1,0 +1,46 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-26768 (fixed)
+ */
+#include "HARD02_fix.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char initialLogFileName[FILENAMESIZE] = "";
+
+void EXPORT_CALL lou_logFile(const char *fileName) {
+  if (fileName == NULL || fileName[0] == 0 || strlen(fileName) >= FILENAMESIZE)
+    return;
+  if (initialLogFileName[0] == 0)
+    strcpy(initialLogFileName, fileName);
+  logFile = fopen(fileName, "a");
+  if (logFile == NULL && initialLogFileName[0] != 0)
+    logFile = fopen(initialLogFileName, "a");
+  if (logFile == NULL) {
+    fprintf(stderr, "Cannot open log file %s\n", fileName);
+    logFile = stderr;
+  }
+}
+
+int main() {
+  const int sz = 260;
+  char *fileName = malloc(sz + 1);
+  memset(fileName, 's', sz);
+  fileName[sz] = '\0';
+  lou_logFile(fileName);
+  free(fileName);
+}

--- a/test/SARIF/GSAC/HARD02_fix/HARD02_fix.h
+++ b/test/SARIF/GSAC/HARD02_fix/HARD02_fix.h
@@ -1,0 +1,35 @@
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+#ifndef HARD02_FIX_H
+#define HARD02_FIX_H
+
+#include <stddef.h>
+
+#define EXPORT_CALL
+
+#ifndef __FILE_defined
+#define __FILE_defined 1
+
+struct _IO_FILE;
+
+typedef struct _IO_FILE FILE;
+
+#endif
+
+extern FILE *stderr;
+#define stderr stderr
+
+#define FILENAMESIZE 256
+
+static FILE *logFile = NULL;
+
+void EXPORT_CALL lou_logFile(const char *fileName);
+
+#endif // HARD02_FIX_H

--- a/test/SARIF/GSAC/MEDIUM01/MEDIUM01.c
+++ b/test/SARIF/GSAC/MEDIUM01/MEDIUM01.c
@@ -1,0 +1,48 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-0185
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PAGE_SHIFT 12
+#define PAGE_SIZE (1ULL << PAGE_SHIFT)
+
+int foo(unsigned int size, const char *key) {
+  size_t len = 3;
+
+  if (len > PAGE_SIZE - 2 - size) {
+    printf("Too large\n");
+    return -1;
+  }
+
+  // 'strlen' can't find '\0'
+  len = strlen(key); // buffer-overflow
+  return len;
+}
+
+int main() {
+  unsigned int size = 4294967295;
+  char *key = malloc(10);
+  // After 'memcpy()' 'key' doesn't have a '\0' symbol
+  memcpy(key, "asddds4323", 10);
+
+  foo(size, key);
+
+  free(key);
+}

--- a/test/SARIF/GSAC/MEDIUM01/pattern.sarif
+++ b/test/SARIF/GSAC/MEDIUM01/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM01.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 15,
+                            "startLine": 41
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM01.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 9,
+                            "startLine": 35
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/MEDIUM01_fix/MEDIUM01_fix.c
+++ b/test/SARIF/GSAC/MEDIUM01_fix/MEDIUM01_fix.c
@@ -1,0 +1,46 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-0185 (fixed)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PAGE_SHIFT 12
+#define PAGE_SIZE (1ULL << PAGE_SHIFT)
+
+int foo(unsigned int size, const char *key) {
+  size_t len = 3;
+
+  if (size + len + 2 > PAGE_SIZE) {
+    printf("Too large\n");
+    return -1;
+  }
+
+  len = strlen(key);
+  return len;
+}
+
+int main() {
+  unsigned int size = 4294967295;
+  char *key = malloc(10);
+  memcpy(key, "asddds432", 10);
+
+  foo(size, key);
+
+  free(key);
+}

--- a/test/SARIF/GSAC/MEDIUM02/MEDIUM02.c
+++ b/test/SARIF/GSAC/MEDIUM02/MEDIUM02.c
@@ -1,0 +1,38 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-3077
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+void foo(int *data) {
+  unsigned char buffer[32 + 16];
+  // Access to 'data' + 4 + 'data[0]' is out of bounds
+  memcpy(&buffer[1], &data[1], data[0]); // buffer-overflow
+}
+
+int main() {
+  int *data = (int *)malloc(4 * sizeof(int));
+  data[0] = 13;
+  data[1] = 2;
+  data[2] = 3;
+  data[3] = 5;
+
+  foo(data);
+
+  free(data);
+}

--- a/test/SARIF/GSAC/MEDIUM02/pattern.sarif
+++ b/test/SARIF/GSAC/MEDIUM02/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 22,
+                            "startLine": 29
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM02.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 3,
+                            "startLine": 25
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/MEDIUM02_fix/MEDIUM02_fix.c
+++ b/test/SARIF/GSAC/MEDIUM02_fix/MEDIUM02_fix.c
@@ -1,0 +1,40 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-3077 (fixed)
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+void foo(int *data) {
+  unsigned char buffer[32 + 16];
+  if (data[0] > 12)
+    return;
+
+  memcpy(&buffer[1], &data[1], data[0]);
+}
+
+int main() {
+  int *data = (int *)malloc(4 * sizeof(int));
+  data[0] = 13;
+  data[1] = 2;
+  data[2] = 3;
+  data[3] = 5;
+
+  foo(data);
+
+  free(data);
+}

--- a/test/SARIF/GSAC/MEDIUM03/MEDIUM03.c
+++ b/test/SARIF/GSAC/MEDIUM03/MEDIUM03.c
@@ -1,0 +1,79 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2023-0819
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct Info {
+  unsigned char *data;
+  int size;
+};
+
+typedef struct {
+  unsigned short year;
+  unsigned char month;
+  unsigned char day;
+  unsigned char hour;
+  unsigned char minute;
+  unsigned char second;
+} TIME;
+
+void foo(struct Info info) {
+  unsigned char *data =
+      info.data; // 'data' is an array with unsigned char elements. With 'info.size' length.
+  int data_size = info.size;
+  TIME time_table;
+
+  unsigned int date, yp, mp, k;
+
+  if (data_size != 5) {
+    printf("Corrupted size\n");
+  }
+
+  date = data[0] * 256 + data[1];
+  yp = (unsigned int)((date - 15078.2) / 365.25);
+  mp = (unsigned int)((date - 14956.1 - (unsigned int)(yp * 365.25)) / 30.6001);
+  time_table.day =
+      (unsigned int)(date - 14956 - (unsigned int)(yp * 365.25) - (unsigned int)(mp * 30.6001));
+  if (mp == 14 || mp == 15)
+    k = 1;
+  else
+    k = 0;
+  time_table.year = yp + k + 1900;
+  time_table.month = mp - 1 - k * 12;
+
+  time_table.hour = 10 * ((data[2] & 0xf0) >> 4) + (data[2] & 0x0f);
+  time_table.minute = 10 * ((data[3] & 0xf0) >> 4) + (data[3] & 0x0f);
+  // Access to 'data' is out of bounds
+  time_table.second = 10 * ((data[4] & 0xf0) >> 4) + (data[4] & 0x0f); // buffer-overflow
+
+  printf("year: %d, month: %d, day: %d, hour: %d, minute: %d, second %d", time_table.year,
+         time_table.month, time_table.day, time_table.hour, time_table.minute, time_table.second);
+}
+
+int main() {
+  struct Info info;
+  info.data = malloc(4); // Memory allocation
+  memcpy(info.data, "asdf", 4);
+  info.size = 4;
+
+  foo(info);
+
+  free(info.data);
+}

--- a/test/SARIF/GSAC/MEDIUM03/pattern.sarif
+++ b/test/SARIF/GSAC/MEDIUM03/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM03.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 15,
+                            "startLine": 72
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM03.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 30,
+                            "startLine": 64
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/MEDIUM03_fix/MEDIUM03_fix.c
+++ b/test/SARIF/GSAC/MEDIUM03_fix/MEDIUM03_fix.c
@@ -1,0 +1,81 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2023-0819 (fixed)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct Info {
+  unsigned char *data;
+  int size;
+};
+
+typedef struct {
+  unsigned short year;
+  unsigned char month;
+  unsigned char day;
+  unsigned char hour;
+  unsigned char minute;
+  unsigned char second;
+} TIME;
+
+void foo(struct Info info) {
+  unsigned char *data = info.data;
+  int data_size = info.size;
+  TIME time_table;
+
+  unsigned int date, yp, mp, k;
+
+  if (data_size != 5) {
+    printf("Corrupted size\n");
+  }
+
+  if (data_size < 5) {
+    return;
+  }
+
+  date = data[0] * 256 + data[1];
+  yp = (unsigned int)((date - 15078.2) / 365.25);
+  mp = (unsigned int)((date - 14956.1 - (unsigned int)(yp * 365.25)) / 30.6001);
+  time_table.day =
+      (unsigned int)(date - 14956 - (unsigned int)(yp * 365.25) - (unsigned int)(mp * 30.6001));
+  if (mp == 14 || mp == 15)
+    k = 1;
+  else
+    k = 0;
+  time_table.year = yp + k + 1900;
+  time_table.month = mp - 1 - k * 12;
+
+  time_table.hour = 10 * ((data[2] & 0xf0) >> 4) + (data[2] & 0x0f);
+  time_table.minute = 10 * ((data[3] & 0xf0) >> 4) + (data[3] & 0x0f);
+  time_table.second = 10 * ((data[4] & 0xf0) >> 4) + (data[4] & 0x0f);
+
+  printf("year: %d, month: %d, day: %d, hour: %d, minute: %d, second %d", time_table.year,
+         time_table.month, time_table.day, time_table.hour, time_table.minute, time_table.second);
+}
+
+int main() {
+  struct Info info;
+  info.data = malloc(4);
+  memcpy(info.data, "asdf", 4);
+  info.size = 4;
+
+  foo(info);
+
+  free(info.data);
+}

--- a/test/SARIF/GSAC/MEDIUM04/MEDIUM04.c
+++ b/test/SARIF/GSAC/MEDIUM04/MEDIUM04.c
@@ -1,0 +1,38 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2023-38559
+ */
+#include <stdlib.h>
+
+void devn_pcx_write_rle(const char *from, const char *end, int step) {
+  while (from < end) {
+    char data = *from;
+
+    from += step;
+    // Access to 'from' is out of range
+    if (data != *from || from == end) { // buffer-overflow
+      return;
+    }
+    from += step;
+  }
+}
+
+int main() {
+  char *a = malloc(sizeof(char));
+  a[0] = 'a';
+  devn_pcx_write_rle(a, a + 4, 4);
+  free(a);
+}

--- a/test/SARIF/GSAC/MEDIUM04/pattern.sarif
+++ b/test/SARIF/GSAC/MEDIUM04/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM04.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 34
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM04.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 17,
+                            "startLine": 26
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/MEDIUM04_fix/MEDIUM04_fix.c
+++ b/test/SARIF/GSAC/MEDIUM04_fix/MEDIUM04_fix.c
@@ -1,0 +1,37 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2023-38559
+ */
+#include <stdlib.h>
+
+void devn_pcx_write_rle(const char *from, const char *end, int step) {
+  while (from < end) {
+    char data = *from;
+
+    from += step;
+    if (from >= end || data != *from) {
+      return;
+    }
+    from += step;
+  }
+}
+
+int main() {
+  char *a = malloc(sizeof(char));
+  a[0] = 'a';
+  devn_pcx_write_rle(a, a + 4, 4);
+  free(a);
+}

--- a/test/SARIF/GSAC/MEDIUM05/MEDIUM05.c
+++ b/test/SARIF/GSAC/MEDIUM05/MEDIUM05.c
@@ -1,0 +1,49 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-23462
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IWNUMBUF_SIZE 32
+
+void iwjson_ftoa(long double val, char buf[static IWNUMBUF_SIZE], size_t *out_len) {
+  // Size of 'buf' is 32 which is less than 64
+  int len = snprintf(buf, 64, "%.8Lf", val); // buffer-overflow
+  if (len <= 0) {
+    buf[0] = '\0';
+    *out_len = 0;
+    return;
+  }
+  while (len > 0 && buf[len - 1] == '0') {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  if ((len > 0) && (buf[len - 1] == '.')) {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  *out_len = (size_t)len;
+}
+
+int main() {
+  char buf[IWNUMBUF_SIZE];
+  size_t *out_len = malloc(sizeof(size_t));
+  *out_len = 50;
+  iwjson_ftoa(12345678912345678912345.1234, buf, out_len);
+  free(out_len);
+}

--- a/test/SARIF/GSAC/MEDIUM05/pattern.sarif
+++ b/test/SARIF/GSAC/MEDIUM05/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Local memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM05.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 8,
+                            "startLine": 44
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "MEDIUM05.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 26
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/GSAC/MEDIUM05_fix/MEDIUM05_fix.c
+++ b/test/SARIF/GSAC/MEDIUM05_fix/MEDIUM05_fix.c
@@ -1,0 +1,48 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: test ! -f %t.klee-out/report.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * Based on CVE-2022-23462 (fixed)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define IWNUMBUF_SIZE 32
+
+void iwjson_ftoa(long double val, char buf[static IWNUMBUF_SIZE], size_t *out_len) {
+  int len = snprintf(buf, IWNUMBUF_SIZE, "%.8Lf", val);
+  if (len <= 0) {
+    buf[0] = '\0';
+    *out_len = 0;
+    return;
+  }
+  while (len > 0 && buf[len - 1] == '0') {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  if ((len > 0) && (buf[len - 1] == '.')) {
+    buf[len - 1] = '\0';
+    len--;
+  }
+  *out_len = (size_t)len;
+}
+
+int main() {
+  char buf[IWNUMBUF_SIZE];
+  size_t *out_len = malloc(sizeof(size_t));
+  *out_len = 50;
+  iwjson_ftoa(12345678912345678912345.1234, buf, out_len);
+  free(out_len);
+}

--- a/test/SARIF/GSAC/PathSensitive/PathSensitive.c
+++ b/test/SARIF/GSAC/PathSensitive/PathSensitive.c
@@ -1,0 +1,36 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+/***************************************************************************************
+ *    Title: GSAC
+ *    Author: https://github.com/GSACTech
+ *    Date: 2023
+ *    Code version: 1.0
+ *    Availability: https://github.com/GSACTech/contest
+ *
+ ***************************************************************************************/
+
+/*
+ * CVE-2023-0819
+ */
+
+#include <stdlib.h>
+
+int main() {
+  int *data;
+  int size = 5;
+  data = malloc(size * sizeof(int)); // Allocated 20 bytes of memory
+  // Length of 'data' is 5
+  for (int i = 0; i < size; i++) {
+    data[i] = i;
+  }
+  if (data[0]) { // Condition is always false
+    data[5] = data[4];
+  }
+  if (data[4]) {
+    data[5] = data[4]; // buffer-overflow
+  }
+  free(data);
+}

--- a/test/SARIF/GSAC/PathSensitive/pattern.sarif
+++ b/test/SARIF/GSAC/PathSensitive/pattern.sarif
@@ -1,0 +1,57 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "PathSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 10,
+                            "startLine": 24
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "PathSensitive.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 13,
+                            "startLine": 33
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/Generic/LazyInitialization/LazyInitialization.c
+++ b/test/SARIF/Generic/LazyInitialization/LazyInitialization.c
@@ -1,0 +1,16 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+#include "klee/klee.h"
+
+#include <stdlib.h>
+
+int main() {
+  char *s;
+  klee_make_symbolic(&s, sizeof(s), "s");
+
+  *s = 100;
+  s[200] = 200;
+}

--- a/test/SARIF/Generic/LazyInitialization/pattern.sarif
+++ b/test/SARIF/Generic/LazyInitialization/pattern.sarif
@@ -1,0 +1,69 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: null pointer exception"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "LazyInitialization.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 6,
+                            "startLine": 14
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "LazyInitialization.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 10,
+                            "startLine": 15
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/Generic/SymbolicSizeArray/SymbolicSizeArray.c
+++ b/test/SARIF/Generic/SymbolicSizeArray/SymbolicSizeArray.c
@@ -1,0 +1,18 @@
+// RUN: %clang -emit-llvm -g -c %s -o %t.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee -write-sarifs --use-sym-size-alloc --use-sym-size-li --skip-not-symbolic-objects --posix-runtime --libc=uclibc -cex-cache-validity-cores --output-dir=%t.klee-out %t.bc > %t.log
+// RUN: %checker %t.klee-out/report.sarif %S/pattern.sarif
+
+#include "klee/klee.h"
+
+#include <stdlib.h>
+
+int main() {
+  int n;
+  klee_make_symbolic(&n, sizeof(n), "n");
+
+  char *s = (char *)malloc(n);
+  s[1] = 10;
+  s[2] = 20;
+  s[0] = 0;
+}

--- a/test/SARIF/Generic/SymbolicSizeArray/pattern.sarif
+++ b/test/SARIF/Generic/SymbolicSizeArray/pattern.sarif
@@ -1,0 +1,106 @@
+{
+  "runs": [
+    {
+      "results": [
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "SymbolicSizeArray.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 21,
+                            "startLine": 14
+                          }
+                        }
+                      },
+                      "metadata": null
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "SymbolicSizeArray.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 8,
+                            "startLine": 15
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Heap memory allocation"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "SymbolicSizeArray.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 21,
+                            "startLine": 14
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "message": {
+                          "text": "memory error: out of bound pointer"
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "SymbolicSizeArray.c"
+                          },
+                          "region": {
+                            "endColumn": null,
+                            "endLine": null,
+                            "startColumn": 8,
+                            "startLine": 16
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/test/SARIF/checker.py
+++ b/test/SARIF/checker.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import os
+
+from typing import Tuple
+
+
+def compare_locations(source, pattern) -> Tuple[bool, str]:
+    try:
+        if source["message"] != pattern["message"]:
+            return (
+                False,
+                f"different messages: {source['message']['text']} vs {pattern['message']['text']}",
+            )
+        if (
+            source["physicalLocation"]["region"]
+            != pattern["physicalLocation"]["region"]
+        ):
+            return (False, "different locations")
+
+        source_path = source["physicalLocation"]["artifactLocation"]["uri"]
+        pattern_path = pattern["physicalLocation"]["artifactLocation"]["uri"]
+
+        if str(source_path).endswith(str(pattern_path)):
+            return (True, "")
+
+        return (False, f"different locations: {source_path} vs {pattern_path}")
+    except KeyError:
+        return (False, "Not a SARIF format given")
+
+
+def validate_source(source, pattern) -> Tuple[bool, str]:
+    try:
+        for result_id in range(len(source["runs"][0]["results"])):
+
+            source_loc = source["runs"][0]["results"][result_id]["codeFlows"][0][
+                "threadFlows"
+            ][0]["locations"][0]["location"]
+            pattern_loc = pattern["runs"][0]["results"][result_id]["codeFlows"][0][
+                "threadFlows"
+            ][0]["locations"][0]["location"]
+
+            (ok, msg) = compare_locations(source_loc, pattern_loc)
+            if not ok:
+                return (
+                    False,
+                    f"Source differs from source in pattern in result #{result_id + 1} : {msg}",
+                )
+
+        return (True, "")
+    except KeyError:
+        return (False, "Not a SARIF format given")
+
+
+def validate_sink(source, pattern) -> Tuple[bool, str]:
+    try:
+        for result_id in range(len(source["runs"][0]["results"])):
+
+            source_loc = source["runs"][0]["results"][result_id]["codeFlows"][0][
+                "threadFlows"
+            ][0]["locations"][-1]["location"]
+            pattern_loc = pattern["runs"][0]["results"][result_id]["codeFlows"][0][
+                "threadFlows"
+            ][0]["locations"][-1]["location"]
+
+            (ok, msg) = compare_locations(source_loc, pattern_loc)
+            if not ok:
+                return (
+                    False,
+                    f"Sink differs from sink in pattern in result #{result_id + 1} : {msg}",
+                )
+
+        return (True, "")
+    except KeyError:
+        return (False, "Not a SARIF format given")
+
+
+def validate(source_file, pattern_file) -> Tuple[bool, str]:
+    try:
+        source = json.load(source_file)
+        pattern = json.load(pattern_file)
+    except json.JSONDecodeError as e:
+        print("Invalid JSON syntax:", e)
+
+    try:
+        if len(source["runs"]) != 1:
+            return (False, "Expected exactly 1 run in source file")
+        if len(pattern["runs"]) != 1:
+            return (False, "Expected exactly 1 run in source file")
+
+        if len(source["runs"][0]["results"]) != len(pattern["runs"][0]["results"]):
+            return (False, "Number of results does not match expected")
+    except KeyError:
+        return (False, "Not a SARIF format given")
+
+    (ok, msg) = validate_source(source, pattern)
+    if not ok:
+        return (ok, msg)
+
+    return validate_sink(source, pattern)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"USAGE: {sys.argv[0]} SOURCE PATTERN", file=sys.stderr)
+        exit(1)
+
+    source_path = sys.argv[1]
+    pattern_path = sys.argv[2]
+
+    with open(source_path, "r") as source_file, open(pattern_path, "r") as pattern_file:
+        (ok, msg) = validate(source_file, pattern_file)
+        if ok:
+            print(f"Validation passed!", file=sys.stderr)
+            exit(0)
+
+        print(f"Validation failed: {msg}!", file=sys.stderr)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/SARIF/lit.local.cfg
+++ b/test/SARIF/lit.local.cfg
@@ -1,0 +1,13 @@
+import os
+
+def getRoot(config):
+    if not config.parent:
+        return config
+    return getRoot(config.parent)
+
+if not getRoot(config).enable_posix_runtime or not getRoot(config).enable_uclibc:
+    config.unsupported = True
+
+config.substitutions.append(
+  ('%checker', f"python3 {os.path.join(os.path.dirname(__file__), 'checker.py')}".strip())
+)


### PR DESCRIPTION
PR providing support for generating error report in SARIF format.

Adds support for reporting errors in SARIF format:
  * Introduces `CodeEvent` as a base unit for storing information about event in code.
  * `CodeEvent`s are managed with `EventRecorder`, capable of serializing recorded trace.
  * `termianateStateOnProgramError` receives an `ErrorEvent` object contatining all required informration about error.

Enhances `gepExprBases`:
  * Bases for addresses stored for constant expressions
  * Precalculates bases for `llvm::ConstantExpr` (i.e. for `getElementPtr` in arguments of instructions)

Removes checks on `baseInBounds` during memory operations.

Adds hacks for managing objects with neighboring addresses (in some cases `gepExprBases` could fail for that case).

Fixes ODR violation with `llvm::APFloat::RoundingMode`.
